### PR TITLE
feat: Github respository의 주소 입력에 따른 commit 목록 요청 및 응답 데이터 저장

### DIFF
--- a/src/feature/commit/store/useCommitStore.js
+++ b/src/feature/commit/store/useCommitStore.js
@@ -1,0 +1,30 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+
+const initialState = {
+  commitList: [],
+};
+
+const useCommitStore = create(
+  persist(
+    (set) => ({
+      ...initialState,
+
+      setCommitList: (newCommitList) =>
+        set(() => ({
+          commitList: newCommitList,
+        })),
+
+      clearCommitList: () =>
+        set(() => ({
+          ...initialState,
+        })),
+    }),
+    {
+      name: "commit-storage",
+      storage: createJSONStorage(() => sessionStorage),
+    }
+  )
+);
+
+export default useCommitStore;

--- a/src/pages/Home/api/getCommitList.js
+++ b/src/pages/Home/api/getCommitList.js
@@ -1,0 +1,51 @@
+const githubToken = import.meta.env.VITE_GITHUB_TOKEN;
+const COMMITS_PER_PAGE = 3;
+
+const getCommitList = async ({
+  organizationName,
+  repositoryName,
+  setCommitList,
+}) => {
+  try {
+    const gitcommitResponse = await fetch(
+      `https://api.github.com/repos/${organizationName}/${repositoryName}/commits?per_page=${COMMITS_PER_PAGE}&page=1`,
+      {
+        headers: {
+          Authorization: `token ${githubToken}`,
+        },
+      }
+    );
+    const gitcommitFirstPage = await gitcommitResponse.json();
+
+    const linkHeader = gitcommitResponse.headers.get("Link");
+    const lastPageNumber = linkHeader
+      ? parseInt(linkHeader.match(/&page=(\d+)>; rel="last"/)?.[1])
+      : 1;
+
+    const allCommits = gitcommitFirstPage;
+
+    if (lastPageNumber > 1) {
+      const fetchPromises = [];
+      for (let page = 2; page <= lastPageNumber; page++) {
+        fetchPromises.push(
+          fetch(
+            `https://api.github.com/repos/${organizationName}/${repositoryName}/commits?per_page=${COMMITS_PER_PAGE}&page=${page}`,
+            {
+              headers: {
+                Authorization: `token ${githubToken}`,
+              },
+            }
+          ).then((res) => res.json())
+        );
+      }
+
+      allCommits.push((await Promise.all(fetchPromises)).flat());
+    }
+
+    setCommitList(allCommits.flat());
+  } catch (error) {
+    throw new Error(error);
+  }
+};
+
+export default getCommitList;

--- a/src/pages/Home/api/getCommitList.js
+++ b/src/pages/Home/api/getCommitList.js
@@ -41,7 +41,6 @@ const getCommitList = async ({
     }
 
     setCommitList(allCommits.flat());
-    console.log(allCommits);
   } catch (error) {
     throw new Error(error);
   }

--- a/src/pages/Home/api/getCommitList.js
+++ b/src/pages/Home/api/getCommitList.js
@@ -6,36 +6,34 @@ const getCommitList = async ({
   repositoryName,
   setCommitList,
 }) => {
-  try {
-    const gitcommitResponse = await fetch(
-      `https://api.github.com/repos/${organizationName}/${repositoryName}/commits?per_page=${COMMITS_PER_PAGE}&page=1`,
-      {
-        headers: {
-          Authorization: `token ${githubToken}`,
-        },
-      }
-    );
-    const gitcommitFirstPage = await gitcommitResponse.json();
+  const commitListUrl = `https://api.github.com/repos/${organizationName}/${repositoryName}/commits?per_page=${COMMITS_PER_PAGE}`;
 
-    const linkHeader = gitcommitResponse.headers.get("Link");
+  const fetchCommits = async (baseUrl, page) => {
+    const gitCommitResponse = await fetch(`${baseUrl}&page=${page}`, {
+      headers: {
+        Authorization: `token ${githubToken}`,
+      },
+    });
+
+    return gitCommitResponse;
+  };
+
+  try {
+    const gitCommitResponse = await fetchCommits(commitListUrl, 1);
+    const gitCommitFirstPage = await gitCommitResponse.json();
+
+    const linkHeader = gitCommitResponse.headers.get("Link");
     const lastPageNumber = linkHeader
       ? parseInt(linkHeader.match(/&page=(\d+)>; rel="last"/)?.[1])
       : 1;
 
-    const allCommits = gitcommitFirstPage;
+    const allCommits = gitCommitFirstPage;
 
     if (lastPageNumber > 1) {
       const fetchPromises = [];
       for (let page = 2; page <= lastPageNumber; page++) {
         fetchPromises.push(
-          fetch(
-            `https://api.github.com/repos/${organizationName}/${repositoryName}/commits?per_page=${COMMITS_PER_PAGE}&page=${page}`,
-            {
-              headers: {
-                Authorization: `token ${githubToken}`,
-              },
-            }
-          ).then((res) => res.json())
+          fetchCommits(commitListUrl, page).then((res) => res.json())
         );
       }
 
@@ -43,6 +41,7 @@ const getCommitList = async ({
     }
 
     setCommitList(allCommits.flat());
+    console.log(allCommits);
   } catch (error) {
     throw new Error(error);
   }

--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -11,10 +11,12 @@ const Home = () => {
 
     const formData = new FormData(e.target);
     const formJson = Object.fromEntries(formData.entries());
-    const [organizationName, repositoryName] = [
-      formJson.organizationName,
-      formJson.repositoryName,
-    ];
+    const parsedURL = formJson.repositoryURL.split("/");
+    const githubIndex = parsedURL.indexOf("github.com");
+    const [organizationName, repositoryName] = parsedURL.slice(
+      githubIndex + 1,
+      githubIndex + 3
+    );
 
     const gitcommitResponse = await fetch(
       `https://api.github.com/repos/${organizationName}/${repositoryName}/commits?per_page=${COMMITS_PER_PAGE}&page=1`,
@@ -57,10 +59,11 @@ const Home = () => {
   return (
     <form method="post" onSubmit={handleRepoInfoSubmit}>
       <label>
-        Organization name:{" "}
-        <input name="organizationName" defaultValue="ex) facebook" />
-        Repository name:{" "}
-        <input name="repositoryName" defaultValue="ex) react" />
+        Repository URL:{" "}
+        <input
+          name="repositoryURL"
+          placeholder="ex) https://github.com/git-marvel/commit-guardians-client"
+        />
       </label>
       <button type="submit">git api 요청</button>
     </form>

--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -1,5 +1,64 @@
+const githubToken = import.meta.env.VITE_GITHUB_TOKEN;
+const COMMITS_PER_PAGE = 100;
+
 const Home = () => {
-  return <h1>Init</h1>;
+  const handleRepoInfoSubmit = async (e) => {
+    e.preventDefault();
+
+    const formData = new FormData(e.target);
+    const formJson = Object.fromEntries(formData.entries());
+    const [organizationName, repositoryName] = [
+      formJson.organizationName,
+      formJson.repositoryName,
+    ];
+
+    const gitcommitResponse = await fetch(
+      `https://api.github.com/repos/${organizationName}/${repositoryName}/commits?per_page=${COMMITS_PER_PAGE}&page=1`,
+      {
+        headers: {
+          Authorization: `token ${githubToken}`,
+        },
+      }
+    );
+    const gitcommitFirstPage = await gitcommitResponse.json();
+
+    const linkHeader = gitcommitResponse.headers.get("Link");
+    const lastPageNumber = linkHeader
+      ? parseInt(linkHeader.match(/&page=(\d+)>; rel="last"/)?.[1])
+      : 1;
+
+    const allCommits = gitcommitFirstPage;
+
+    if (lastPageNumber > 1) {
+      const fetchPromises = [];
+      for (let page = 2; page <= lastPageNumber; page++) {
+        fetchPromises.push(
+          fetch(
+            `https://api.github.com/repos/${organizationName}/${repositoryName}/commits?per_page=${COMMITS_PER_PAGE}&page=${page}`,
+            {
+              headers: {
+                Authorization: `token ${githubToken}`,
+              },
+            }
+          ).then((res) => res.json())
+        );
+      }
+
+      allCommits.push((await Promise.all(fetchPromises)).flat());
+    }
+  };
+
+  return (
+    <form method="post" onSubmit={handleRepoInfoSubmit}>
+      <label>
+        Organization name:{" "}
+        <input name="organizationName" defaultValue="ex) facebook" />
+        Repository name:{" "}
+        <input name="repositoryName" defaultValue="ex) react" />
+      </label>
+      <button type="submit">git api 요청</button>
+    </form>
+  );
 };
 
 export default Home;

--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -1,7 +1,11 @@
+import useCommitStore from "../../feature/commit/store/useCommitStore";
+
 const githubToken = import.meta.env.VITE_GITHUB_TOKEN;
-const COMMITS_PER_PAGE = 100;
+const COMMITS_PER_PAGE = 3;
 
 const Home = () => {
+  const setCommitList = useCommitStore((state) => state.setCommitList);
+
   const handleRepoInfoSubmit = async (e) => {
     e.preventDefault();
 
@@ -46,6 +50,8 @@ const Home = () => {
 
       allCommits.push((await Promise.all(fetchPromises)).flat());
     }
+
+    setCommitList(allCommits.flat());
   };
 
   return (

--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -1,25 +1,17 @@
 import useCommitStore from "../../feature/commit/store/useCommitStore";
-import messages from "../../shared/constants/messages";
+import extractGitInfoFromURL from "../../shared/utils/extractGitInfoFromURL";
 import getCommitList from "./api/getCommitList";
 
 const Home = () => {
   const setCommitList = useCommitStore((state) => state.setCommitList);
 
-  const handleRepoInfoSubmit = async (e) => {
-    e.preventDefault();
+  const handleRepoInfoSubmit = async (event) => {
+    event.preventDefault();
 
-    const formData = new FormData(e.target);
-    const formJson = Object.fromEntries(formData.entries());
-    const parsedURL = formJson.repositoryURL.split("/");
-    const githubIndex = parsedURL.indexOf("github.com");
-    const [organizationName, repositoryName] = parsedURL.slice(
-      githubIndex + 1,
-      githubIndex + 3
-    );
-
-    if (!organizationName || !repositoryName) {
-      throw new Error(messages.errors.invalidURL);
-    }
+    const formData = new FormData(event.target);
+    const repositoryURL = Object.fromEntries(formData.entries()).repositoryURL;
+    const { organizationName, repositoryName } =
+      extractGitInfoFromURL(repositoryURL);
 
     try {
       getCommitList({ organizationName, repositoryName, setCommitList });

--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -63,6 +63,7 @@ const Home = () => {
         <input
           name="repositoryURL"
           placeholder="ex) https://github.com/git-marvel/commit-guardians-client"
+          required
         />
       </label>
       <button type="submit">git api 요청</button>

--- a/src/shared/constants/messages.js
+++ b/src/shared/constants/messages.js
@@ -1,0 +1,12 @@
+const messages = {
+  errors: {
+    invalidURL:
+      "적합하지 않은 URL입니다. [https://github.com/소유자이름/레포지토리이름/...] 혹은 [github.com/소유자이름/레포지토리이름/] 처럼 URL를 넣어주세요!",
+    invalidGithubURL:
+      "Github에서 찾을 수 없는 링크입니다. 혹시 Repository가 private으로 설정 되어 있나요?",
+    serverError:
+      "Commit 목록을 받아오는데 오류가 생겼습니다. 조금 뒤 다시 시도해주세요.",
+  },
+};
+
+export default messages;

--- a/src/shared/utils/extractGitInfoFromURL.js
+++ b/src/shared/utils/extractGitInfoFromURL.js
@@ -1,0 +1,16 @@
+import messages from "../constants/messages";
+
+const extractGitInfoFromURL = (url) => {
+  const parsedLink = url.split("/");
+  const githubIndex = parsedLink.indexOf("github.com");
+  const organizationName = parsedLink[githubIndex + 1];
+  const repositoryName = parsedLink[githubIndex + 2];
+
+  if (!organizationName || !repositoryName) {
+    throw new Error(messages.errors.invalidURL);
+  }
+
+  return { organizationName, repositoryName };
+};
+
+export default extractGitInfoFromURL;


### PR DESCRIPTION
# 이슈

🔗 이슈 링크: https://github.com/git-marvel/commit-guardians-client/issues/9

# 요약
사용자가 Github respository의 주소를 입력하고 버튼을 누르면, 해당 repository의 commit 목록들이 전역 상태로 저장됩니다.
- Zustand를 이용하여 commit 목록을 저장할 store와 state를 생성 하였습니다.
- Error message를 저장할 파일을 생성하였습니다.

# Mock Up (선택)

# 구현화면

# 작업내용

- [x] 첫 페이지의 commit 목록을 요청 및 응답 확인
- [x] 첫 응답에서 총 요청 가능한 페이지 개수 추출
- [x] 추가 페이지가 있다면 나머지 commit 목록 페이지 요청
  - [x] 비동기적 요청 구현
  - [x] 순차적인 응답 저장
- [x] 에러 처리 구현
- [x] #27 
  - [x] Store를 fsd 폴더 구조에 맞게 생성
  - [x] Store의 state와 action을 commit을 담을 수 있게 생성
  - [x] 평탄화 된 commit 목록 내용을 state에 저장

# 참고사항
- UI가 적용되지 않았습니다.
- UI, UX 작업시에 throw한 error을 기반으로 Error 메시지의 처리를 하시면 좋겠습니다.

# PR 체크 사항

## 주의 사항
X

## PR 전 체크리스트

- [X] 가장 최신 브랜치를 pull 하였습니다.
- [X] base 브랜치명을 확인하였습니다.
- [X] 코드 컨벤션을 모두 확인하였습니다.
- [X] 브랜치명을 확인하였습니다.

---

## 리뷰 반영사항

- [X] fetch시에 반복되는 로직과 url을 재사용가능 하게 함수와 상수로 변경하였습니다.
- [X] url을 파싱하는 로직을 util 파일로 분리하였습니다.
