### PR TITLE
feat: 뱃지 UI 만들기및 클립보드 복사 기능

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist-ssr
 .DS_Store
 
 /package-lock.json
+.env

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:run": "vitest run"
   },
   "dependencies": {
+    "firebase": "^11.0.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.27.0",

--- a/src/app/router.jsx
+++ b/src/app/router.jsx
@@ -1,11 +1,21 @@
 import { createBrowserRouter } from "react-router-dom";
 import Home from "../pages/Home";
+import MyCommitBadge from "../pages/MyCommitBadge";
+import MyCommitScoreboard from "../pages/MyCommitScoreboard";
 import NotFound from "../pages/NotFound";
 
 const router = createBrowserRouter([
   {
     path: "/",
     element: <Home />,
+  },
+  {
+    path: "/my-commit-badge",
+    element: <MyCommitBadge />,
+  },
+  {
+    path: "/my-commit-scoreboard",
+    element: <MyCommitScoreboard />,
   },
   {
     path: "*",

--- a/src/features/commitBadge/components/CopyBadge.jsx
+++ b/src/features/commitBadge/components/CopyBadge.jsx
@@ -1,0 +1,23 @@
+import Badge from "../../../shared/components/Badge";
+import Snackbar from "../../../shared/components/SnackBar";
+import useCopiedBadge from "../hooks/useCopyBadge";
+
+const CopyBadge = () => {
+  const { isCopied, error, copyBadgeTag, badgeTagUrl } = useCopiedBadge();
+
+  return (
+    <>
+      {error && <Snackbar message={error.message} />}
+      {isCopied && <Snackbar message="복사 성공!" />}
+      <div className="h-40">{badgeTagUrl && <Badge url={badgeTagUrl} />}</div>
+      <button
+        className="mb-2 rounded-lg border border-gray-200 bg-white px-5 py-2.5 text-sm font-medium text-gray-900 transition duration-300 ease-in-out hover:bg-stone-900 hover:text-lime-300 focus:z-10 focus:outline-none focus:ring-4 focus:ring-gray-100 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-stone-100 dark:hover:text-stone-900 dark:focus:ring-gray-700"
+        onClick={copyBadgeTag}
+      >
+        커밋 뱃지 복사하기
+      </button>
+    </>
+  );
+};
+
+export default CopyBadge;

--- a/src/features/commitBadge/hooks/useCopyBadge.jsx
+++ b/src/features/commitBadge/hooks/useCopyBadge.jsx
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useState } from "react";
+import { getBadgeUrl } from "../services";
+
+const COPIED_DURATION_MS = 2000;
+
+const useCopiedBadge = () => {
+  const [badgeTagUrl, setBadgeTagUrl] = useState(null);
+  const [isCopied, setIsCopied] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchBadgeUrl = async () => {
+      try {
+        const svgUrl = await getBadgeUrl({ qualityPercent: 100 });
+
+        setBadgeTagUrl(svgUrl);
+      } catch (err) {
+        setError(`뱃지 불러오기를 실패했네요..🥲, ${err}`);
+      }
+    };
+
+    fetchBadgeUrl();
+  }, []);
+
+  const copyBadgeTag = useCallback(async () => {
+    try {
+      const badgeTag = `<a href="https://github.com/git-marvel/commit-guardians-client">
+  <img src="${badgeTagUrl}" />
+</a>`;
+
+      await navigator.clipboard.writeText(badgeTag);
+
+      setIsCopied(true);
+      setError(null);
+
+      setTimeout(() => {
+        setIsCopied(false);
+      }, COPIED_DURATION_MS);
+
+      return badgeTag;
+    } catch (error) {
+      setError(`뱃지 복사를 실패했네요..🥲, ${error}`);
+    }
+  }, [badgeTagUrl]);
+
+  return { isCopied, error, copyBadgeTag, badgeTagUrl };
+};
+
+export default useCopiedBadge;

--- a/src/features/commitBadge/services/index.js
+++ b/src/features/commitBadge/services/index.js
@@ -1,0 +1,20 @@
+import { getDownloadURL, ref } from "firebase/storage";
+import { storage } from "../../../shared/config";
+
+const getBadgeUrl = async ({ qualityPercent }) => {
+  let fileRef;
+
+  if (qualityPercent >= 80) {
+    fileRef = ref(storage, "badges/commit-rulemaster-style-01.svg");
+  } else if (qualityPercent >= 50) {
+    fileRef = ref(storage, "badges/commit-hardworker-style-02.svg");
+  } else if (qualityPercent >= 30) {
+    fileRef = ref(storage, "badges/commit-newbie-style-03.svg");
+  } else {
+    fileRef = ref(storage, "badges/commit-myway-style-04.svg");
+  }
+
+  return await getDownloadURL(fileRef);
+};
+
+export { getBadgeUrl };

--- a/src/pages/MyCommitBadge/index.jsx
+++ b/src/pages/MyCommitBadge/index.jsx
@@ -9,9 +9,7 @@ const MyCommitBadge = () => {
 
   return (
     <>
-      <Button onClick={handleRoutingCommitScoreboard}>
-        <p>💯 10 commits</p>
-      </Button>
+      <Button onClick={handleRoutingCommitScoreboard}>💯 10 commits</Button>
       <CopyBadgeButton />
       <Footer />
     </>

--- a/src/pages/MyCommitBadge/index.jsx
+++ b/src/pages/MyCommitBadge/index.jsx
@@ -1,0 +1,21 @@
+import { useNavigate } from "react-router-dom";
+import CopyBadgeButton from "../../features/commitBadge/components/CopyBadge";
+import Button from "../../shared/components/Button";
+import Footer from "../../shared/components/Footer";
+
+const MyCommitBadge = () => {
+  const navigate = useNavigate();
+  const handleRoutingCommitScoreboard = () => navigate("/my-commit-scoreboard");
+
+  return (
+    <>
+      <Button onClick={handleRoutingCommitScoreboard}>
+        <p>💯 10 commits</p>
+      </Button>
+      <CopyBadgeButton />
+      <Footer />
+    </>
+  );
+};
+
+export default MyCommitBadge;

--- a/src/pages/MyCommitScoreboard/index.jsx
+++ b/src/pages/MyCommitScoreboard/index.jsx
@@ -1,0 +1,5 @@
+const MyCommitScoreboard = () => {
+  return <h1>MyCommitScoreboard</h1>;
+};
+
+export default MyCommitScoreboard;

--- a/src/pages/NotFound/index.jsx
+++ b/src/pages/NotFound/index.jsx
@@ -13,11 +13,7 @@ const NotFound = () => {
         code="404"
         heading="Page Not Found 🤔"
         paragraph="The page you are looking for does not exist."
-        button={
-          <Button onClick={handleRoutingHome}>
-            <p>Go to Home</p>
-          </Button>
-        }
+        button={<Button onClick={handleRoutingHome}>Go to Home</Button>}
       />
       <Footer />
     </>

--- a/src/pages/NotFound/index.jsx
+++ b/src/pages/NotFound/index.jsx
@@ -13,7 +13,11 @@ const NotFound = () => {
         code="404"
         heading="Page Not Found 🤔"
         paragraph="The page you are looking for does not exist."
-        button={<Button onClick={handleRoutingHome}>{"Go to Home"}</Button>}
+        button={
+          <Button onClick={handleRoutingHome}>
+            <p>Go to Home</p>
+          </Button>
+        }
       />
       <Footer />
     </>

--- a/src/shared/components/Badge.jsx
+++ b/src/shared/components/Badge.jsx
@@ -1,0 +1,17 @@
+import PropTypes from "prop-types";
+
+const Badge = ({ url }) => {
+  const githubUrl = "https://github.com/git-marvel/commit-guardians-client";
+
+  return (
+    <a href={githubUrl} target="_blank" rel="noopener noreferrer">
+      <img src={url} alt="Commit Guardians Badge" />
+    </a>
+  );
+};
+
+Badge.propTypes = {
+  url: PropTypes.string.isRequired,
+};
+
+export default Badge;

--- a/src/shared/components/Button.jsx
+++ b/src/shared/components/Button.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 const Button = ({ onClick, children }) => {
   return (
     <button
-      className="mb-2 me-2 rounded-lg border border-gray-200 bg-white px-5 py-2.5 text-sm font-medium text-gray-900 hover:bg-gray-100 hover:text-purple-600 focus:z-10 focus:outline-none focus:ring-4 focus:ring-gray-100 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white dark:focus:ring-gray-700"
+      className="mb-2 rounded-lg border border-gray-200 bg-white px-5 py-2.5 text-sm font-medium text-gray-900 hover:bg-gray-100 hover:text-purple-600 focus:z-10 focus:outline-none focus:ring-4 focus:ring-gray-100 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white dark:focus:ring-gray-700"
       onClick={onClick}
     >
       {children}

--- a/src/shared/components/Button.jsx
+++ b/src/shared/components/Button.jsx
@@ -13,7 +13,7 @@ const Button = ({ onClick, children }) => {
 
 Button.propTypes = {
   onClick: PropTypes.func.isRequired,
-  children: PropTypes.element.isRequired,
+  children: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 };
 
 export default Button;

--- a/src/shared/components/SnackBar.jsx
+++ b/src/shared/components/SnackBar.jsx
@@ -2,7 +2,7 @@ import PropTypes from "prop-types";
 
 const Snackbar = ({ message }) => {
   return (
-    <div className="animate-wiggleFadeOut fixed left-auto top-5 z-50 rounded-lg bg-lime-300 px-6 py-2 text-sm text-black">
+    <div className="fixed left-auto top-5 z-50 animate-wiggleFadeOut rounded-lg bg-lime-300 px-6 py-2 text-sm text-black">
       {message}
     </div>
   );

--- a/src/shared/components/SnackBar.jsx
+++ b/src/shared/components/SnackBar.jsx
@@ -1,0 +1,15 @@
+import PropTypes from "prop-types";
+
+const Snackbar = ({ message }) => {
+  return (
+    <div className="animate-wiggleFadeOut fixed left-auto top-5 z-50 rounded-lg bg-lime-300 px-6 py-2 text-sm text-black">
+      {message}
+    </div>
+  );
+};
+
+Snackbar.propTypes = {
+  message: PropTypes.string.isRequired,
+};
+
+export default Snackbar;

--- a/src/shared/config/index.js
+++ b/src/shared/config/index.js
@@ -1,0 +1,18 @@
+import { initializeApp } from "firebase/app";
+import { getStorage } from "firebase/storage";
+
+const firebaseConfig = {
+  apiKey: import.meta.env.VITE_API_KEY,
+  authDomain: import.meta.env.VITE_AUTH_DOMAIN,
+  databaseURL: import.meta.env.VITE_DATA_BASE_URL,
+  projectId: import.meta.env.VITE_PROJECT_ID,
+  storageBucket: import.meta.env.VITE_STORAGE_BUCKET,
+  messagingSenderId: import.meta.env.VITE_MESSAGING_SENDER_ID,
+  appId: import.meta.env.VITE_APP_ID,
+  measurementId: import.meta.env.VITE_MEASUREMENT_ID,
+};
+
+const app = initializeApp(firebaseConfig);
+const storage = getStorage(app);
+
+export { storage };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,18 @@
 export default {
   content: ["./index.html", "./src/**/*.{js,jsx}"],
   theme: {
-    extend: {},
+    extend: {
+      keyframes: {
+        wiggleFadeOut: {
+          "0%": { transform: "rotate(-3deg)", opacity: "1" },
+          "50%": { transform: "rotate(3deg)", opacity: "1" },
+          "100%": { transform: "rotate(-3deg)", opacity: "0" },
+        },
+      },
+      animation: {
+        wiggleFadeOut: "wiggleFadeOut 2s ease-in-out",
+      },
+    },
     fontFamily: {
       Pixelify: ["Pixelify"],
     },


### PR DESCRIPTION
# 이슈

🔗 이슈 링크 https://github.com/git-marvel/commit-guardians-client/issues/15

# 요약

- 결과 페이지에서 보여줄 뱃지와 깃허브 repository README에 붙여넣기할 링크를 복사할 수 있는 기능을 추가했습니다.

# Mock Up (선택)
<img width="886" alt="Screenshot 2024-11-05 at 9 32 55 PM" src="https://github.com/user-attachments/assets/93884608-6864-4028-9011-c0a3a180fcf8">

# 구현화면
### 웹화면
<img width="1798" alt="Screenshot 2024-11-05 at 9 33 18 PM" src="https://github.com/user-attachments/assets/104842a9-47bf-450e-a4a8-730560d3c37a">

### 뱃지 적용화면
<img width="1417" alt="Screenshot 2024-11-05 at 9 34 13 PM" src="https://github.com/user-attachments/assets/6048e45c-d2ef-4cf1-a1ed-54836ff13ccc">

# 작업내용

- [x] firebase storage 에 이미지를 저장했습니다.
- [x] 커밋 퀄리티 퍼센트에 따라 이미지를 분기처리 하여 렌더링합니다.
- [x] 클립보드에 복사할 수 있는 기능을 추가했습니다.

# 참고사항

- env 파일을 gitignore 에 추가했습니다.
- 머지되면 `npm i` 로 의존성 추가설치해주세요!

# PR 체크 사항

## 주의 사항

- [x] 다음 기능을 구현하기 전에 `.env` 파일을 요청해주세요!
- [x] 만약 먼저 merge 된다면, conflict를 모두 해결하고 PR을 올려주세요!

## PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] `badge` 브랜치명임을 확인하였습니다.

---

## 리뷰 반영사항

- [x] [Button 컴포넌트 propTypes 다중지원](https://ko.legacy.reactjs.org/docs/typechecking-with-proptypes.html)
