### PR TITLE
feat: 커밋 목록들 중, 커밋 퀄리티를 검사할 수 있는 커밋들만 저장하기

### DIFF
--- a/src/entities/commitType/services/index.js
+++ b/src/entities/commitType/services/index.js
@@ -8,13 +8,23 @@ const FILTER_TYPE_LIST = new Map([
 ]);
 
 const getCheckCommitList = (commitList) => {
-  const getCommitType = (commit) => commit.message.split(":")[0];
+  const getCommitType = (element) => element.commit.message.split(":")[0];
   const removeParentheses = (input) => input.replace(/\(.*\)$/, "");
   const filteredCommitList = commitList.filter((commit) =>
     FILTER_TYPE_LIST.has(removeParentheses(getCommitType(commit)))
   );
 
-  return filteredCommitList;
+  return filteredCommitList.map((element) => {
+    const { sha, url, commit } = element;
+    const { author, message } = commit;
+
+    return {
+      sha,
+      url,
+      author,
+      message,
+    };
+  });
 };
 
 export { getCheckCommitList };

--- a/src/entities/commitType/services/index.js
+++ b/src/entities/commitType/services/index.js
@@ -1,0 +1,20 @@
+const FILTER_TYPE_LIST = new Map([
+  ["remove", true],
+  ["removed", true],
+  ["removes", true],
+  ["delete", true],
+  ["test", true],
+  ["docs", true],
+]);
+
+const getCheckCommitList = (commitList) => {
+  const getCommitType = (commit) => commit.message.split(":")[0];
+  const removeParentheses = (input) => input.replace(/\(.*\)$/, "");
+  const filteredCommitList = commitList.filter((commit) =>
+    FILTER_TYPE_LIST.has(removeParentheses(getCommitType(commit)))
+  );
+
+  return filteredCommitList;
+};
+
+export { getCheckCommitList };

--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -1,6 +1,7 @@
 import useCommitStore from "../../features/commit/store/useCommitStore";
 import extractGitInfoFromURL from "../../shared/utils/extractGitInfoFromURL";
-import { getCommitList } from "./api";
+import { getCheckCommitList } from "../../entities/commitType/services";
+import { getCommitDiffList, getCommitList } from "./api";
 
 const Home = () => {
   const setCommitList = useCommitStore((state) => state.setCommitList);
@@ -10,11 +11,18 @@ const Home = () => {
 
     const formData = new FormData(event.target);
     const repositoryURL = Object.fromEntries(formData.entries()).repositoryURL;
-    const { organizationName, repositoryName } =
-      extractGitInfoFromURL(repositoryURL);
+    const { owner, repo } = extractGitInfoFromURL(repositoryURL);
 
     try {
-      getCommitList({ organizationName, repositoryName, setCommitList });
+      const commitList = await getCommitList({ owner, repo });
+      const checkCommitList = getCheckCommitList(commitList);
+      const changeList = await getCommitDiffList({
+        owner,
+        repo,
+        checkCommitList,
+      });
+
+      setCommitList(changeList);
     } catch (error) {
       throw new Error(error.messages);
     }

--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -22,7 +22,9 @@ const Home = () => {
         checkCommitList,
       });
 
-      setCommitList(changeList);
+      const jsonMap = changeList.map((change) => Array.from(change.values()));
+
+      setCommitList(jsonMap);
     } catch (error) {
       throw new Error(error.messages);
     }

--- a/src/shared/utils/extractGitInfoFromURL.js
+++ b/src/shared/utils/extractGitInfoFromURL.js
@@ -3,14 +3,14 @@ import { ERROR_MESSAGES } from "../constants";
 const extractGitInfoFromURL = (url) => {
   const parsedLink = url.split("/");
   const githubIndex = parsedLink.indexOf("github.com");
-  const organizationName = parsedLink[githubIndex + 1];
-  const repositoryName = parsedLink[githubIndex + 2];
+  const owner = parsedLink[githubIndex + 1];
+  const repo = parsedLink[githubIndex + 2];
 
-  if (!organizationName || !repositoryName) {
+  if (!owner || !repo) {
     throw new Error(ERROR_MESSAGES.invalidURL);
   }
 
-  return { organizationName, repositoryName };
+  return { owner, repo };
 };
 
 export default extractGitInfoFromURL;


### PR DESCRIPTION
# 이슈

🔗 이슈 링크: https://github.com/git-marvel/commit-guardians-client/issues/10

# 요약
응답 받아 저장한 커밋 목록을 바탕으로, tag를 통해 검사할 커밋들의 변경 내용(diff)를 비동기로 요청합니다.
변경 내용을 순차적으로 전역 state로 저장합니다.

# 구현화면
![image](https://github.com/user-attachments/assets/58b13339-e0f7-47f8-8861-108809e1064b)

# 작업내용

- [x] 커밋 목록을 순회하며 tag를 통해 커밋 필터링
  - [x] 필터링 된 커밋들의 속성 중 필요한 속성만 저장
  - [x] 필터링 된 커밋들의 sha를 이용해 diff를 비동기적으로 요청

# 참고사항

- change의 map type이 sessionStorage에 올바르지 않아 array로 바꾸어 주었습니다.
![image](https://github.com/user-attachments/assets/7b5126ac-f30d-4ced-96e6-44e03209b7f7)

- Organization name을 owner로, repository name을 repo로 통일 하였습니다.
- getCommitDiff 함수의 ref 파라미터를 sha로 변경하였습니다.

# PR 체크 사항

## 주의 사항
- 없음

## PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.

---

## 리뷰 반영사항

- [ ]
