### PR TITLE
refactor: Fetch를 axios로 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:run": "vitest run"
   },
   "dependencies": {
+    "axios": "^1.7.7",
     "firebase": "^11.0.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/pages/Home/api/index.js
+++ b/src/pages/Home/api/index.js
@@ -24,7 +24,7 @@ const getCommitList = async ({ owner, repo }) => {
     const gitCommitFirstPage = await fetchWithAuth(
       `${commitListUrl}&page=${1}`
     );
-    const linkHeader = gitCommitFirstPage.headers["link"];
+    const linkHeader = gitCommitFirstPage.headers["Link"];
     const lastPageNumber = linkHeader
       ? parseInt(linkHeader.match(/&page=(\d+)>; rel="last"/)?.[1])
       : 1;

--- a/src/pages/Home/api/index.js
+++ b/src/pages/Home/api/index.js
@@ -1,3 +1,4 @@
+import axios from "axios";
 import { getChanges } from "../../../entities/change/services";
 import { GITHUB_TOKEN } from "../../../shared/constants";
 
@@ -8,7 +9,7 @@ const setCommitBaseUrl = ({ owner, repo }) =>
   `https://api.github.com/repos/${owner}/${repo}/commits`;
 
 const fetchWithAuth = async (url, accept = "*/*") => {
-  return await fetch(url, {
+  return await axios.get(url, {
     headers: {
       Authorization: `token ${GITHUB_TOKEN}`,
       Accept: accept,
@@ -20,26 +21,28 @@ const getCommitList = async ({ owner, repo }) => {
   const commitListUrl = `${setCommitBaseUrl({ owner, repo })}?per_page=${COMMITS_PER_PAGE}`;
 
   try {
-    const gitCommitResponse = await fetchWithAuth(`${commitListUrl}&page=${1}`);
-    const linkHeader = gitCommitResponse.headers.get("Link");
+    const gitCommitFirstPage = await fetchWithAuth(
+      `${commitListUrl}&page=${1}`
+    );
+    const linkHeader = gitCommitFirstPage.headers["link"];
     const lastPageNumber = linkHeader
       ? parseInt(linkHeader.match(/&page=(\d+)>; rel="last"/)?.[1])
       : 1;
 
-    const gitCommitFirstPage = await gitCommitResponse.json();
-    const allCommits = gitCommitFirstPage;
+    const allCommits = gitCommitFirstPage.data;
 
     if (lastPageNumber > 1) {
       const fetchPromises = [];
 
       for (let page = 2; page <= lastPageNumber; page++) {
-        const commitPromise = async () => {
-          const response = await fetchWithAuth(`${commitListUrl}&page=${page}`);
-
-          return await response.json();
+        const commitPagePromise = async () => {
+          const commitPage = await fetchWithAuth(
+            `${commitListUrl}&page=${page}`
+          );
+          return commitPage.data;
         };
 
-        fetchPromises.push(commitPromise());
+        fetchPromises.push(commitPagePromise());
       }
 
       allCommits.push((await Promise.all(fetchPromises)).flat());
@@ -55,7 +58,7 @@ const getCommitDiff = async ({ owner, repo, sha }) => {
   const commitUrl = `${setCommitBaseUrl({ owner, repo })}/${sha}`;
 
   const response = await fetchWithAuth(commitUrl, DIFF_MEDIA_TYPE);
-  const changedCode = await response.text();
+  const changedCode = response.data;
 
   return getChanges(changedCode);
 };
@@ -64,13 +67,11 @@ const getCommitDiffList = async ({ owner, repo, checkCommitList }) => {
   const fetchPromises = [];
   checkCommitList.forEach((element) => {
     const { sha } = element;
-    const commitPromise = async () => {
-      const changes = await getCommitDiff({ owner, repo, sha });
-
-      return changes;
+    const commitDiffPromise = async () => {
+      return await getCommitDiff({ owner, repo, sha });
     };
 
-    fetchPromises.push(commitPromise());
+    fetchPromises.push(commitDiffPromise());
   });
 
   return await Promise.all(fetchPromises);


### PR DESCRIPTION
# 이슈

🔗 이슈 링크: https://github.com/git-marvel/commit-guardians-client/issues/35

# 요약
Fetch 함수를 axios 패키지의 axios 함수로 대체하여 다음과 같은 효과를 기대 할 수 있습니다.
- 스크립트가 어떠한 역할을 하는지 가독성 개선이 있습니다.
- json() 비동기 메서드를 따로 사용하지 않고 정보를 취득할 수 있습니다.
![image](https://github.com/user-attachments/assets/de3841ca-0e37-4bbd-847d-99c60b0dfd24)

위의 대체와 함께 영향을 받은 변수, 함수명의 변경이 있었습니다.


# 작업내용
- [X] Fetch를 axios로 변경

# 참고사항
- axios 패키지가 추가되어, merge된 branch에서는 추가로 패키지 설치가 필요합니다.

# PR 체크 사항

## 주의 사항
- 없음

## PR 전 체크리스트

- [X] 가장 최신 브랜치를 pull 하였습니다.
- [X] base 브랜치명을 확인하였습니다.
- [X] 코드 컨벤션을 모두 확인하였습니다.
- [X] 브랜치명을 확인하였습니다.

---

## 리뷰 반영사항

- [X] "Link" 오타 반영
