### PR TITLE
feat: 대용량 데이터 처리 로직에 대한 응답을 기다리는 동안 보여질 로딩 UI 구현

### DIFF
--- a/src/pages/Home/hooks/useValidateCommit.jsx
+++ b/src/pages/Home/hooks/useValidateCommit.jsx
@@ -1,16 +1,18 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { getCheckableCommits } from "../../../entities/commit/services";
 import useCommitStore from "../../../features/commit/store/useCommitStore";
 import extractGitInfoFromURL from "../../../shared/utils/extractGitInfoFromURL";
 import { getCommitDiffList, getCommitList } from "../api";
 
 const useValidateCommit = () => {
+  const [isLoading, setIsLoading] = useState(false);
   const setCommitList = useCommitStore((state) => state.setCommitList);
   const commitList = useCommitStore((state) => state.commitList);
 
   const handleCheckCommitQuality = useCallback(
     async (event) => {
       event.preventDefault();
+      setIsLoading(true);
 
       const formData = new FormData(event.target);
       const repositoryURL = Object.fromEntries(
@@ -28,15 +30,17 @@ const useValidateCommit = () => {
           commitsToCheck,
         });
 
+        setIsLoading(false);
         setCommitList(diffList);
       } catch (error) {
+        setIsLoading(false);
         throw new Error(error);
       }
     },
     [setCommitList]
   );
 
-  return { commitList, handleCheckCommitQuality };
+  return { isLoading, commitList, handleCheckCommitQuality };
 };
 
 export default useValidateCommit;

--- a/src/pages/Home/hooks/useValidateCommit.jsx
+++ b/src/pages/Home/hooks/useValidateCommit.jsx
@@ -30,11 +30,11 @@ const useValidateCommit = () => {
           commitsToCheck,
         });
 
-        setIsLoading(false);
         setCommitList(diffList);
       } catch (error) {
-        setIsLoading(false);
         throw new Error(error);
+      } finally {
+        setIsLoading(false);
       }
     },
     [setCommitList]

--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -1,8 +1,9 @@
 import Button from "../../shared/components/Button";
+import Loading from "../../shared/components/Loading";
 import useValidateCommit from "./hooks/useValidateCommit";
 
 const Home = () => {
-  const { commitList, handleCheckCommitQuality } = useValidateCommit();
+  const { isLoading, commitList, handleCheckCommitQuality } = useValidateCommit();
 
   return (
     <div className="absolute top-0 m-10">
@@ -18,6 +19,7 @@ const Home = () => {
         </label>
         <Button>커밋 퀄리티 확인하기</Button>
       </form>
+      {isLoading && <Loading />}
       {commitList.map((commit, index) => (
         <div key={commit.sha}>
           <div className="mt-10 bg-lime-100">

--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -3,7 +3,8 @@ import Loading from "../../shared/components/Loading";
 import useValidateCommit from "./hooks/useValidateCommit";
 
 const Home = () => {
-  const { isLoading, commitList, handleCheckCommitQuality } = useValidateCommit();
+  const { isLoading, commitList, handleCheckCommitQuality } =
+    useValidateCommit();
 
   return (
     <div className="absolute top-0 m-10">

--- a/src/shared/components/Loading.jsx
+++ b/src/shared/components/Loading.jsx
@@ -1,0 +1,22 @@
+import PropTypes from "prop-types";
+
+const Loading = ({ message="결과를 불러오고 있어요" }) => {
+
+  return (
+    <>
+      <div className="w-1/2 my-5">
+        <div className="h-1 w-full bg-neutral-300">
+          <div className="animate-loadingProgressBar h-1 bg-black"></div>
+        </div>
+      </div>
+      <p className="font-Pixelify text-2xl">Loading...</p>
+      <p className="text-sm mt-3">{message}</p>
+    </>
+  );
+}
+
+Loading.propTypes = {
+  message: PropTypes.string,
+};
+
+export default Loading;

--- a/src/shared/components/Loading.jsx
+++ b/src/shared/components/Loading.jsx
@@ -1,19 +1,18 @@
 import PropTypes from "prop-types";
 
-const Loading = ({ message="결과를 불러오고 있어요" }) => {
-
+const Loading = ({ message = "결과를 불러오고 있어요" }) => {
   return (
     <>
-      <div className="w-1/2 my-5">
+      <div className="my-5 w-1/2">
         <div className="h-1 w-full bg-neutral-300">
-          <div className="animate-loadingProgressBar h-1 bg-black"></div>
+          <div className="h-1 animate-loadingProgressBar bg-black"></div>
         </div>
       </div>
       <p className="font-Pixelify text-2xl">Loading...</p>
-      <p className="text-sm mt-3">{message}</p>
+      <p className="mt-3 text-sm">{message}</p>
     </>
   );
-}
+};
 
 Loading.propTypes = {
   message: PropTypes.string,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,9 +8,14 @@ export default {
           "50%": { transform: "rotate(3deg)", opacity: "1" },
           "100%": { transform: "rotate(-3deg)", opacity: "0" },
         },
+        loadingProgressBar: {
+          "0%": { width: "0%" },
+          "100%": { width: "100%" },
+        },
       },
       animation: {
         wiggleFadeOut: "wiggleFadeOut 2s ease-in-out",
+        loadingProgressBar: "loadingProgressBar 2s linear infinite",
       },
     },
     fontFamily: {


### PR DESCRIPTION
# 이슈

🔗 이슈 링크 [#33](https://github.com/git-marvel/commit-guardians-client/issues/33)

# 요약

- 커밋 메시지에 대한 처리를 하는 동안 보여질 로딩 페이지입니다.



# 구현화면
![image](https://github.com/user-attachments/assets/f56dc74b-aa93-4674-a6da-981c99b81780)

# 작업내용

- [x] 로딩 컴포넌트 만들기
- [x] 커밋 검증 처리 로직이 실행되는 동안 로딩 컴포넌트 띄우기
- [x] 재사용 가능하도록 리팩토링

# PR 체크 사항

## 주의 사항

- [x] conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.

---

## 리뷰 반영사항

- [ ]
