### PR TITLE
feat: 100%인 커밋들 수 / 검사한 모든 커밋들 수 계산하기

### DIFF
--- a/src/entities/score/services/index.js
+++ b/src/entities/score/services/index.js
@@ -1,0 +1,21 @@
+/**
+ * @param {Array} scoredCommitList - 점수가 매겨진 commit들의 목록
+ * @returns {Object} 100점인 커밋의 개수와 비율을 포함한 객체
+ * @returns {number} return.perfectCommitNumber - 점수가 100점인 커밋의 개수
+ * @returns {number} return.finalQualityPercent - 전체 커밋 중 완벽한 커밋의 백분율 (0%일 경우 최소 1%로 조정)
+ */
+const getTotalQualityPercent = (scoredCommitList) => {
+  const perfectCommitNumber = scoredCommitList.filter(
+    (scoredCommit) => scoredCommit.score === 100
+  ).length;
+  const totalQualityPercent =
+    Math.floor(perfectCommitNumber / scoredCommitList.length) * 100;
+  const finalQualityPercent =
+    totalQualityPercent === 0 && perfectCommitNumber > 0
+      ? 1
+      : totalQualityPercent;
+
+  return { perfectCommitNumber, finalQualityPercent };
+};
+
+export { getTotalQualityPercent };

--- a/src/entities/score/services/index.js
+++ b/src/entities/score/services/index.js
@@ -1,8 +1,6 @@
 /**
  * @param {Array} scoredCommitList - 점수가 매겨진 commit들의 목록
- * @returns {Object} 100점인 커밋의 개수와 비율을 포함한 객체
- * @returns {number} return.perfectCommitNumber - 점수가 100점인 커밋의 개수
- * @returns {number} return.finalQualityPercent - 전체 커밋 중 완벽한 커밋의 백분율 (0%일 경우 최소 1%로 조정)
+ * @returns {{ perfectCommitNumber: number, finalQualityPercent: number }}
  */
 const getTotalQualityPercent = (scoredCommitList) => {
   const perfectCommitNumber = scoredCommitList.filter(

--- a/src/entities/score/services/index.js
+++ b/src/entities/score/services/index.js
@@ -8,8 +8,9 @@ const getTotalQualityPercent = (scoredCommitList) => {
   const perfectCommitNumber = scoredCommitList.filter(
     (scoredCommit) => scoredCommit.score === 100
   ).length;
-  const totalQualityPercent =
-    Math.floor(perfectCommitNumber / scoredCommitList.length) * 100;
+  const totalQualityPercent = Math.floor(
+    (perfectCommitNumber / scoredCommitList.length) * 100
+  );
   const finalQualityPercent =
     totalQualityPercent === 0 && perfectCommitNumber > 0
       ? 1

--- a/src/features/commit/store/useCommitStore.js
+++ b/src/features/commit/store/useCommitStore.js
@@ -24,7 +24,7 @@ const useCommitStore = create(
           scoredCommitInfo: newScoredCommitInfo,
         })),
 
-      clearCommitList: () =>
+      clearAll: () =>
         set(() => ({
           ...initialState,
         })),

--- a/src/features/commit/store/useCommitStore.js
+++ b/src/features/commit/store/useCommitStore.js
@@ -4,7 +4,7 @@ import { createJSONStorage, persist } from "zustand/middleware";
 const initialState = {
   commitInfo: {
     commitList: [],
-    commitNumber: null,
+    numOfCommit: null,
     totalCommitNumber: null,
   },
   scoredCommitInfo: {
@@ -23,7 +23,7 @@ const useCommitStore = create(
           commitInfo: {
             ...state.commitInfo,
             commitList: newCommitList,
-            commitNumber: newCommitList.length,
+            numOfCommit: newCommitList.length,
           },
         })),
 

--- a/src/features/commit/store/useCommitStore.js
+++ b/src/features/commit/store/useCommitStore.js
@@ -3,6 +3,10 @@ import { createJSONStorage, persist } from "zustand/middleware";
 
 const initialState = {
   commitList: [],
+  scoredCommitInfo: {
+    perfectCommitNumber: null,
+    finalQualityPercent: null,
+  },
 };
 
 const useCommitStore = create(

--- a/src/features/commit/store/useCommitStore.js
+++ b/src/features/commit/store/useCommitStore.js
@@ -19,6 +19,11 @@ const useCommitStore = create(
           commitList: newCommitList,
         })),
 
+      setScoredCommitInfo: (newScoredCommitInfo) =>
+        set(() => ({
+          scoredCommitInfo: newScoredCommitInfo,
+        })),
+
       clearCommitList: () =>
         set(() => ({
           ...initialState,

--- a/src/features/commit/store/useCommitStore.js
+++ b/src/features/commit/store/useCommitStore.js
@@ -2,7 +2,11 @@ import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
 const initialState = {
-  commitList: [],
+  commitInfo: {
+    commitList: [],
+    commitNumber: null,
+    totalCommitNumber: null,
+  },
   scoredCommitInfo: {
     perfectCommitNumber: null,
     finalQualityPercent: null,
@@ -15,8 +19,20 @@ const useCommitStore = create(
       ...initialState,
 
       setCommitList: (newCommitList) =>
-        set(() => ({
-          commitList: newCommitList,
+        set((state) => ({
+          commitInfo: {
+            ...state.commitInfo,
+            commitList: newCommitList,
+            commitNumber: newCommitList.length,
+          },
+        })),
+
+      setTotalCommitNumber: (totalCommitNumber) =>
+        set((state) => ({
+          commitInfo: {
+            ...state.commitInfo,
+            totalCommitNumber: totalCommitNumber,
+          },
         })),
 
       setScoredCommitInfo: (newScoredCommitInfo) =>

--- a/src/features/commit/store/useCommitStore.js
+++ b/src/features/commit/store/useCommitStore.js
@@ -5,7 +5,7 @@ const initialState = {
   commitInfo: {
     commitList: [],
     numOfCommit: null,
-    totalCommitNumber: null,
+    totalNumOfCommit: null,
   },
   scoredCommitInfo: {
     perfectCommitNumber: null,
@@ -27,11 +27,11 @@ const useCommitStore = create(
           },
         })),
 
-      setTotalCommitNumber: (totalCommitNumber) =>
+      setTotalNumOfCommit: (totalNumOfCommit) =>
         set((state) => ({
           commitInfo: {
             ...state.commitInfo,
-            totalCommitNumber: totalCommitNumber,
+            totalNumOfCommit: totalNumOfCommit,
           },
         })),
 

--- a/src/pages/Home/api/index.js
+++ b/src/pages/Home/api/index.js
@@ -25,7 +25,7 @@ const getCommitList = async ({ owner, repo }) => {
     const gitCommitFirstPage = await fetchWithAuth(
       `${commitListUrl}&page=${1}`
     );
-    const linkHeader = gitCommitFirstPage.headers["Link"];
+    const linkHeader = gitCommitFirstPage.headers["link"];
     const lastPageNumber = linkHeader
       ? parseInt(linkHeader.match(/&page=(\d+)>; rel="last"/)?.[1])
       : 1;

--- a/src/pages/Home/hooks/useValidateCommit.jsx
+++ b/src/pages/Home/hooks/useValidateCommit.jsx
@@ -7,8 +7,8 @@ import { getCommitDiffList, getCommitList } from "../api";
 const useValidateCommit = () => {
   const [isLoading, setIsLoading] = useState(false);
   const setCommitList = useCommitStore((state) => state.setCommitList);
-  const setTotalCommitNumber = useCommitStore(
-    (state) => state.setTotalCommitNumber
+  const setTotalNumOfCommit = useCommitStore(
+    (state) => state.setTotalNumOfCommit
   );
   const commitList = useCommitStore((state) => state.commitInfo.commitList);
 
@@ -33,7 +33,7 @@ const useValidateCommit = () => {
           commitsToCheck,
         });
 
-        setTotalCommitNumber(allCommits.length);
+        setTotalNumOfCommit(allCommits.length);
         setCommitList(diffList);
       } catch (error) {
         throw new Error(error);
@@ -41,7 +41,7 @@ const useValidateCommit = () => {
         setIsLoading(false);
       }
     },
-    [setCommitList, setTotalCommitNumber]
+    [setCommitList, setTotalNumOfCommit]
   );
 
   return { isLoading, commitList, handleCheckCommitQuality };

--- a/src/pages/Home/hooks/useValidateCommit.jsx
+++ b/src/pages/Home/hooks/useValidateCommit.jsx
@@ -6,9 +6,7 @@ import { getCommitDiffList, getCommitList } from "../api";
 
 const useValidateCommit = () => {
   const [isLoading, setIsLoading] = useState(false);
-  const setCommitList = useCommitStore(
-    (state) => state.commitInfo.setCommitList
-  );
+  const setCommitList = useCommitStore((state) => state.setCommitList);
   const setTotalCommitNumber = useCommitStore(
     (state) => state.setTotalCommitNumber
   );

--- a/src/pages/Home/hooks/useValidateCommit.jsx
+++ b/src/pages/Home/hooks/useValidateCommit.jsx
@@ -6,8 +6,13 @@ import { getCommitDiffList, getCommitList } from "../api";
 
 const useValidateCommit = () => {
   const [isLoading, setIsLoading] = useState(false);
-  const setCommitList = useCommitStore((state) => state.setCommitList);
-  const commitList = useCommitStore((state) => state.commitList);
+  const setCommitList = useCommitStore(
+    (state) => state.commitInfo.setCommitList
+  );
+  const setTotalCommitNumber = useCommitStore(
+    (state) => state.setTotalCommitNumber
+  );
+  const commitList = useCommitStore((state) => state.commitInfo.commitList);
 
   const handleCheckCommitQuality = useCallback(
     async (event) => {
@@ -30,6 +35,7 @@ const useValidateCommit = () => {
           commitsToCheck,
         });
 
+        setTotalCommitNumber(allCommits.length);
         setCommitList(diffList);
       } catch (error) {
         throw new Error(error);
@@ -37,7 +43,7 @@ const useValidateCommit = () => {
         setIsLoading(false);
       }
     },
-    [setCommitList]
+    [setCommitList, setTotalCommitNumber]
   );
 
   return { isLoading, commitList, handleCheckCommitQuality };

--- a/src/pages/MyCommitBadge/index.jsx
+++ b/src/pages/MyCommitBadge/index.jsx
@@ -2,14 +2,20 @@ import { useNavigate } from "react-router-dom";
 import CopyBadgeButton from "../../features/commitBadge/components/CopyBadge";
 import Button from "../../shared/components/Button";
 import Footer from "../../shared/components/Footer";
+import useCommitStore from "../../features/commit/store/useCommitStore";
 
 const MyCommitBadge = () => {
   const navigate = useNavigate();
   const handleRoutingCommitScoreboard = () => navigate("/my-commit-scoreboard");
+  const perfectCommitNumber = useCommitStore(
+    (state) => state.scoredCommitInfo.perfectCommitNumber
+  );
 
   return (
     <>
-      <Button onClick={handleRoutingCommitScoreboard}>💯 10 commits</Button>
+      <Button
+        onClick={handleRoutingCommitScoreboard}
+      >{`💯 ${perfectCommitNumber} commits`}</Button>
       <CopyBadgeButton />
       <Footer />
     </>


### PR DESCRIPTION
# 이슈

🔗 이슈 링크: https://github.com/git-marvel/commit-guardians-client/issues/14

# 요약
커밋 검증 결과 페이지로 이동하는 버튼 안에 100점을 맞은 커밋의 개수를 표시한다.

# Mock Up
![image](https://github.com/user-attachments/assets/5f5e3773-608d-43fa-88c2-f298db81669c)

# 구현화면
변경된 버튼 모습 (null state 반영, 실제로는 숫자가 출력 될 때만 작동)
![image](https://github.com/user-attachments/assets/c1148e32-c1dc-49e4-bd90-d7f62ca3c36f)

수정 된 store에 저장된 모습
![image](https://github.com/user-attachments/assets/f56000ac-12b0-4a8e-b554-65fd28a135c2)


# 작업내용

- [X] 100%의 점수를 받은 커밋의 개수를 구하는 로직 구현
- [x] 검증된 커밋과 skip된 커밋의 수를 구하는 로직 구현
- [X] (100%인 커밋들의 수/ 검사한 모든 커밋들)의 결과를 기준으로 각 단계별 등급 지정: getBadgeUrl
      * 80% 이상 : 커밋규칙왕
      * 50% 이상 : 커밋노력파
      * 30% 이상 : 커밋 뉴비
      * 나머지 : 커밋 개성파
- [X] 100%를 받은 커밋개수를 표시할 UI 구현

# 참고사항
- getTotalQualityPercent는 현재 사용되지 않고, 채점 과정이 완료되면 사용 될 수 있습니다.
- Zustand store에 변경사항이 있으니 사용에 주의 해주시기 바랍니다.

# PR 체크 사항

## 주의 사항

- [X] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [X] conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [X] 가장 최신 브랜치를 pull 하였습니다.
- [X] base 브랜치명을 확인하였습니다.
- [X] 코드 컨벤션을 모두 확인하였습니다.
- [X] 브랜치명을 확인하였습니다.

---

## 리뷰 반영사항
- [X] 함수의 JSDocs 주석 변경
- [X] 개수의 변수명을 ~Number 대신 numOf~로 변경
- [X] 점수 채점 로직 오류 수정
