### PR TITLE
feat: 커밋 타입이 Remove 인 경우, 커밋 퀄리티점수를 계산하는 로직을 추가

### DIFF
--- a/src/entities/change/changeEntity.js
+++ b/src/entities/change/changeEntity.js
@@ -1,11 +1,7 @@
 const createChangeEntity = ({ key, previousContent, content }) => {
   const toggleKey = key === "-" ? "+" : "-";
-  const toggleContent =
-    previousContent[toggleKey] === undefined ? "" : previousContent[toggleKey];
-  const keyContent =
-    previousContent[key] === undefined
-      ? `${content}\n`
-      : (previousContent[key] += `${content}\n`);
+  const toggleContent = previousContent[toggleKey] || "";
+  const keyContent = (previousContent[key] || "") + `${content}\n`;
 
   return {
     [key]: keyContent,

--- a/src/entities/commit/commitEntity.js
+++ b/src/entities/commit/commitEntity.js
@@ -1,3 +1,6 @@
+import COMMIT_TYPE from "./enum/commitTypeEnum";
+import scoreRemoveCommitType from "./services/scoreRemoveCommitType";
+
 /**
  * @param {{type: COMMIT_TYPE.type,
  *          sha: string,
@@ -15,6 +18,7 @@ const createCommitEntity = ({ type, sha, url, author, message }) => {
     diffObj: null,
     numOfFiles: null,
     numOfChanges: null,
+    qualityScore: null,
   };
 };
 
@@ -25,4 +29,16 @@ const makeCommitEntityWithDiff = ({ commit, diffObj }) => {
   return commit;
 };
 
-export { createCommitEntity, makeCommitEntityWithDiff };
+const setCommitQualityScore = ({ commit, commitType, diffObj }) => {
+  switch (commitType) {
+    case COMMIT_TYPE.remove.type: {
+      const qualityScore = scoreRemoveCommitType(diffObj); // remove 에 따른 점수가
+      commit.qualityScore = qualityScore;
+      break;
+    }
+    default:
+      return 0;
+  }
+};
+
+export { createCommitEntity, makeCommitEntityWithDiff, setCommitQualityScore };

--- a/src/entities/commit/commitEntity.js
+++ b/src/entities/commit/commitEntity.js
@@ -38,7 +38,7 @@ const makeCommitEntityWithDiff = ({ commit, diffObj }) => {
 const setCommitQualityScore = ({ commit, commitType, diffObj }) => {
   switch (commitType) {
     case COMMIT_TYPE.remove.type: {
-      const qualityScore = scoreRemoveCommitType(diffObj); // remove 에 따른 점수가
+      const qualityScore = scoreRemoveCommitType(diffObj);
       commit.qualityScore = qualityScore;
       break;
     }

--- a/src/entities/commit/commitEntity.js
+++ b/src/entities/commit/commitEntity.js
@@ -2,11 +2,17 @@ import COMMIT_TYPE from "./enum/commitTypeEnum";
 import scoreRemoveCommitType from "./services/scoreRemoveCommitType";
 
 /**
- * @param {{type: COMMIT_TYPE.type,
- *          sha: string,
- *          url: string,
- *          author: {date: string, email: string, name: string},
- *          message: string}}
+ * @param {{
+ * type: COMMIT_TYPE.type,
+ * sha: string,
+ * url: string,
+ * author: {date: string, email: string, name: string},
+ * message: string,
+ * diffObj: {"FILE_NAME.example": [{"+": string, "-": string}, ...]},
+ * numOfFiles: number,
+ * numOfChanges: number,
+ * qualityScore: number,
+ * }}
  */
 const createCommitEntity = ({ type, sha, url, author, message }) => {
   return {

--- a/src/entities/commit/services/scoreRemoveCommitType.js
+++ b/src/entities/commit/services/scoreRemoveCommitType.js
@@ -18,8 +18,9 @@ const calculateModuleFileDeletions = (fileName, changes) => {
   );
 
   const modifications = changes.filter((change) => {
-    const hasDeletion = change["-"] && change["-"].length > 0;
-    const hasAddition = change["+"] && change["+"].length > 0;
+    const hasDeletion = change["-"] !== undefined && change["-"].length > 0;
+    const hasAddition = change["+"] !== undefined && change["+"].length > 0;
+
     return hasDeletion && hasAddition;
   });
 

--- a/src/entities/commit/services/scoreRemoveCommitType.js
+++ b/src/entities/commit/services/scoreRemoveCommitType.js
@@ -91,8 +91,3 @@ const scoreRemoveCommitType = (diffObj) => {
 };
 
 export default scoreRemoveCommitType;
-export {
-  calculateFileScore,
-  calculateModuleFileDeletions,
-  isOnlyDeletionChange,
-};

--- a/src/entities/commit/services/scoreRemoveCommitType.js
+++ b/src/entities/commit/services/scoreRemoveCommitType.js
@@ -1,0 +1,98 @@
+const MODULE_FILE_EXTENSIONS = [".json", ".yaml"];
+
+/**
+ * 조건 1. 모듈 파일의 유효한 삭제 변경사항 개수를 계산하는 함수
+ * @param {string} fileName - 파일 이름
+ * @param {Array} changes - 변경사항 목록
+ * @returns {number || undefined} - 유효한 삭제 변경사항 개수 (순수 삭제 - 수정) || 모듈파일 확장자가 아닌 경우 undefined 를 반환
+ */
+const calculateModuleFileDeletions = (fileName, changes) => {
+  if (
+    !MODULE_FILE_EXTENSIONS.some((extension) => fileName.endsWith(extension))
+  ) {
+    return;
+  }
+
+  const pureDeletions = changes.filter((change) =>
+    isOnlyDeletionChange(change)
+  );
+
+  const modifications = changes.filter((change) => {
+    const hasDeletion = change["-"] && change["-"].length > 0;
+    const hasAddition = change["+"] && change["+"].length > 0;
+    return hasDeletion && hasAddition;
+  });
+
+  return pureDeletions.length - modifications.length;
+};
+
+/**
+ * 조건 2. 변경사항이 삭제만 있는지 확인하는 함수입니다.
+ * @param {Object} change - 변경사항 객체
+ * @returns {boolean} - 삭제만 있는지 여부
+ */
+const isOnlyDeletionChange = (change) => {
+  const hasDeletion = change["-"] !== undefined && change["-"].length > 0;
+  const hasNoAddition =
+    change["+"] === undefined || change["+"] === null || change["+"] === "";
+
+  return hasDeletion && hasNoAddition;
+};
+
+/**
+ * 파일별 삭제 점수를 계산하는 함수입니다.
+ * @param {Array} changes - 파일의 변경사항 목록
+ * @param {string} fileName - 파일 이름
+ * @returns {number} - 파일의 삭제 점수
+ */
+const calculateFileScore = (fileName, changes) => {
+  const changesLength = changes.length;
+
+  if (!changes || changesLength === 0) {
+    return 0;
+  }
+
+  const numOfPerfectChanges = calculateModuleFileDeletions(fileName, changes);
+
+  if (numOfPerfectChanges !== undefined) {
+    return Math.floor((numOfPerfectChanges / changesLength) * 100);
+  }
+
+  const validDeletionCount = changes.reduce((count, change) => {
+    return isOnlyDeletionChange(change) ? count + 1 : count;
+  }, 0);
+
+  return Math.floor((validDeletionCount / changesLength) * 100);
+};
+
+/**
+ * remove 커밋 타입의 변경사항을 검증하고 점수를 합계하고 평균을 내는 함수입니다.
+ * @param {Object} diffObj - 변경사항 객체
+ * @returns {number} - 최종 점수
+ */
+const scoreRemoveCommitType = (diffObj) => {
+  if (!diffObj || Object.keys(diffObj).length === 0) {
+    return 0;
+  }
+
+  const validFiles = Object.entries(diffObj).filter(
+    ([, changes]) => Array.isArray(changes) && changes.length > 0
+  );
+
+  if (validFiles.length === 0) {
+    return 0;
+  }
+
+  const totalScore = validFiles.reduce((sum, [fileName, changes]) => {
+    return sum + calculateFileScore(fileName, changes);
+  }, 0);
+
+  return Math.floor(totalScore / validFiles.length);
+};
+
+export default scoreRemoveCommitType;
+export {
+  calculateFileScore,
+  calculateModuleFileDeletions,
+  isOnlyDeletionChange,
+};

--- a/src/features/commit/components/CommitValidationMark.jsx
+++ b/src/features/commit/components/CommitValidationMark.jsx
@@ -1,0 +1,15 @@
+import PropTypes from "prop-types";
+
+const CommitQualityScore = ({ qualityScore }) => {
+  return (
+    <div className={`w-20 rounded px-1 py-1 text-xl font-bold text-blue-500`}>
+      Score: {qualityScore}
+    </div>
+  );
+};
+
+CommitQualityScore.propTypes = {
+  qualityScore: PropTypes.number.isRequired,
+};
+
+export default CommitQualityScore;

--- a/src/features/commit/components/CommitValidationMark.jsx
+++ b/src/features/commit/components/CommitValidationMark.jsx
@@ -2,7 +2,7 @@ import PropTypes from "prop-types";
 
 const CommitQualityScore = ({ qualityScore }) => {
   return (
-    <div className={`w-20 rounded px-1 py-1 text-xl font-bold text-blue-500`}>
+    <div className="w-20 rounded px-1 py-1 text-xl font-bold text-blue-500">
       Score: {qualityScore}
     </div>
   );

--- a/src/pages/Home/hooks/useValidateCommit.jsx
+++ b/src/pages/Home/hooks/useValidateCommit.jsx
@@ -1,4 +1,5 @@
 import { useCallback, useState } from "react";
+import { setCommitQualityScore } from "../../../entities/commit/commitEntity";
 import { getCheckableCommits } from "../../../entities/commit/services";
 import useCommitStore from "../../../features/commit/store/useCommitStore";
 import extractGitInfoFromURL from "../../../shared/utils/extractGitInfoFromURL";
@@ -27,14 +28,23 @@ const useValidateCommit = () => {
         const allCommits = await getCommitList({ owner, repo });
         const commitsToCheck = getCheckableCommits(allCommits);
 
-        const diffList = await getCommitDiffList({
+        const commitWithDiff = await getCommitDiffList({
           owner,
           repo,
           commitsToCheck,
         });
 
         setTotalNumOfCommit(allCommits.length);
-        setCommitList(diffList);
+
+        commitWithDiff.forEach((commit) => {
+          setCommitQualityScore({
+            commit,
+            commitType: commit.type,
+            diffObj: commit.diffObj,
+          });
+        });
+
+        setCommitList(commitWithDiff);
       } catch (error) {
         throw new Error(error);
       } finally {

--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -1,3 +1,4 @@
+import CommitQualityScore from "../../features/commit/components/CommitValidationMark";
 import Button from "../../shared/components/Button";
 import Loading from "../../shared/components/Loading";
 import useValidateCommit from "./hooks/useValidateCommit";
@@ -24,26 +25,33 @@ const Home = () => {
       {commitList.map((commit, index) => (
         <div key={commit.sha}>
           <div className="mt-10 bg-lime-100">
+            {commit.qualityScore !== null &&
+              commit.qualityScore !== undefined && (
+                <CommitQualityScore qualityScore={commit.qualityScore} />
+              )}
             <span className="p-1 text-red-500">index: {index}</span>
             <span className="p-1 text-slate-400">sha: {commit.sha}</span>
             <span className="p-3 text-green-400">{commit.type}</span>
             <span>message: {commit.message}</span>
           </div>
-          {Object.entries(commit.diffObj).map(([key, changes]) => (
-            <div key={key}>
-              <span className="p-1 text-blue-500">File: {key}</span>
-              {changes.map((change, changeIndex) => (
-                <div key={changeIndex}>
-                  {change["+"] && (
-                    <span className="p-1 text-green-500">+ {change["+"]}</span>
-                  )}
-                  {change["-"] && (
-                    <span className="p-1 text-red-500">- {change["-"]}</span>
-                  )}
-                </div>
-              ))}
-            </div>
-          ))}
+          {commit.diffObj &&
+            Object.entries(commit.diffObj).map(([key, changes]) => (
+              <div key={key}>
+                <span className="p-1 text-blue-500">File: {key}</span>
+                {changes.map((change, changeIndex) => (
+                  <div key={changeIndex}>
+                    {change["+"] && (
+                      <span className="p-1 text-green-500">
+                        + {change["+"]}
+                      </span>
+                    )}
+                    {change["-"] && (
+                      <span className="p-1 text-red-500">- {change["-"]}</span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            ))}
         </div>
       ))}
     </div>


### PR DESCRIPTION
# 이슈

🔗 이슈 링크 https://github.com/git-marvel/commit-guardians-client/issues/4

# 요약

- 커밋 타입이 Remove 인 경우, 커밋 퀄리티점수를 확인할 수 있습니다.

# 구현화면
<img width="902" alt="Screenshot 2024-11-10 at 10 56 57 PM" src="https://github.com/user-attachments/assets/57f4584b-711e-4dd5-9568-90ec6e11772a">

# 작업내용

- [x] 커밋타입 remove 에 대한 커밋퀄리티 점수 계산하는 기능
- [x] 커밋타입에 따른 퀄리티점수를 반환하는 함수 작성 및 commitWithDiff 를 순회하면서, 커밋퀄리티 계산로직 추가
- [x] CommitQualityScore 를 보여주는 컴포넌트 작성
- [x] createChangeEntity 의 함수 내부 리팩토링

# 참고사항

- 이후 docs 타입의 경우를 작성할 때, `commitEntity` 안의 `setCommitQualityScore` 함수에 삽입하면 됩니다!
<img width="472" alt="Screenshot 2024-11-10 at 10 58 31 PM" src="https://github.com/user-attachments/assets/b894f7af-a52f-4f66-9de3-aa71ebadca9a">

# PR 체크 사항

## 주의 사항

- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] remove 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.

---

## 리뷰 반영사항

- [ ]
