### PR TITLE
feat: 커밋 타입이 docs인 커밋의 퀄리티 계산 로직 추가

### DIFF
--- a/src/entities/commit/commitEntity.js
+++ b/src/entities/commit/commitEntity.js
@@ -1,4 +1,5 @@
 import COMMIT_TYPE from "./enum/commitTypeEnum";
+import scoreDocsCommitType from "./services/scoreDocsCommitType";
 import scoreRemoveCommitType from "./services/scoreRemoveCommitType";
 
 /**
@@ -36,15 +37,20 @@ const makeCommitEntityWithDiff = ({ commit, diffObj }) => {
 };
 
 const setCommitQualityScore = ({ commit, commitType, diffObj }) => {
+  let qualityScore = 0;
+
   switch (commitType) {
     case COMMIT_TYPE.remove.type: {
-      const qualityScore = scoreRemoveCommitType(diffObj);
-      commit.qualityScore = qualityScore;
+      qualityScore = scoreRemoveCommitType(diffObj);
       break;
     }
-    default:
-      return 0;
+    case COMMIT_TYPE.docs.type: {
+      qualityScore = scoreDocsCommitType(diffObj);
+      break;
+    }
   }
+
+  commit.qualityScore = qualityScore;
 };
 
 export { createCommitEntity, makeCommitEntityWithDiff, setCommitQualityScore };

--- a/src/entities/commit/services/index.js
+++ b/src/entities/commit/services/index.js
@@ -33,7 +33,7 @@ const makeCommitTypeWithFormatStyle = (firstWordOfCommitMessage) => {
  * @returns {Array} checkableCommits - 검사 가능한 커밋 목록
  */
 const getCheckableCommits = (totalCommits) => {
-  const checkableCommits = totalCommits.reduce((accumulatorList, commit) => {
+  const checkableCommits = totalCommits.reduce((accumulators, commit) => {
     const firstWord = commit.commit.message.split(" ")[0];
     const commitType = makeCommitTypeWithFormatStyle(firstWord);
 
@@ -46,10 +46,10 @@ const getCheckableCommits = (totalCommits) => {
         message: commit.commit.message,
       });
 
-      accumulatorList.push(commitWithType);
+      accumulators.push(commitWithType);
     }
 
-    return accumulatorList;
+    return accumulators;
   }, []);
 
   return checkableCommits;

--- a/src/entities/commit/services/index.js
+++ b/src/entities/commit/services/index.js
@@ -30,7 +30,7 @@ const makeCommitTypeWithFormatStyle = (firstWordOfCommitMessage) => {
 
 /**
  * @param {Array} totalCommits - 모든 커밋 목록
- * @returns {Array} checkableCommitList - 검사 가능한 커밋 목록
+ * @returns {Array} checkableCommits - 검사 가능한 커밋 목록
  */
 const getCheckableCommits = (totalCommits) => {
   const checkableCommits = totalCommits.reduce((accumulatorList, commit) => {

--- a/src/entities/commit/services/scoreDocsCommitType.js
+++ b/src/entities/commit/services/scoreDocsCommitType.js
@@ -1,0 +1,31 @@
+const DOCS_TYPE_FILENAME_EXTENSIONS = [
+  ".docs",
+  ".md",
+  ".mdx",
+  ".img",
+  ".png",
+  ".jpeg",
+  ".svg",
+  ".ai",
+  ".pdf",
+];
+
+/**
+ * @param {Object} diffObj - 변경사항 객체
+ * @returns {number} commitScore - 최종 점수
+ */
+const scoreDocsCommitType = (diffObj) => {
+  const passedFilesCount = Object.keys(diffObj).filter((filePath) => {
+    return DOCS_TYPE_FILENAME_EXTENSIONS.some((extension) =>
+      filePath.endsWith(extension)
+    );
+  }).length;
+
+  const commitScore = Math.floor(
+    (passedFilesCount / Object.keys(diffObj).length) * 100
+  );
+
+  return commitScore;
+};
+
+export default scoreDocsCommitType;

--- a/src/pages/Home/hooks/useValidateCommit.jsx
+++ b/src/pages/Home/hooks/useValidateCommit.jsx
@@ -17,7 +17,6 @@ const useValidateCommit = () => {
   const handleCheckCommitQuality = useCallback(
     async (event) => {
       event.preventDefault();
-      setIsLoading(true);
 
       const formData = new FormData(event.target);
       const repositoryURL = Object.fromEntries(
@@ -25,6 +24,8 @@ const useValidateCommit = () => {
       ).repositoryURL;
 
       try {
+        setIsLoading(true);
+
         const { owner, repo } = extractGitInfoFromURL(repositoryURL);
         const allCommits = await getCommitList({ owner, repo });
         const commitsToCheck = getCheckableCommits(allCommits);

--- a/src/pages/Home/hooks/useValidateCommit.jsx
+++ b/src/pages/Home/hooks/useValidateCommit.jsx
@@ -18,13 +18,13 @@ const useValidateCommit = () => {
     async (event) => {
       event.preventDefault();
 
-      const formData = new FormData(event.target);
-      const repositoryURL = Object.fromEntries(
-        formData.entries()
-      ).repositoryURL;
-
       try {
         setIsLoading(true);
+
+        const formData = new FormData(event.target);
+        const repositoryURL = Object.fromEntries(
+          formData.entries()
+        ).repositoryURL;
 
         const { owner, repo } = extractGitInfoFromURL(repositoryURL);
         const allCommits = await getCommitList({ owner, repo });


### PR DESCRIPTION
# 이슈

🔗 이슈 링크 [#5](https://github.com/git-marvel/commit-guardians-client/issues/5)

# 요약

- 커밋 타입 docs인 커밋의 점수를 계산하는 함수입니다.


# 작업내용

- [x] 문서에 사용되는 파일만을 고려한다.
  * 이미지 파일 - .img, .png, .jpeg, .svg, . ai
  * .pdf
  * .docs
  * .md, mdx


# PR 체크 사항

## 주의 사항

- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!

---

## 리뷰 반영사항

- [ ]
