### PR TITLE
feat: 커밋타입 test인 커밋의 퀄리티 점수 계산 로직 작성

### DIFF
--- a/src/entities/commit/commitEntity.js
+++ b/src/entities/commit/commitEntity.js
@@ -38,24 +38,20 @@ const makeCommitEntityWithDiff = ({ commit, diffObj }) => {
 };
 
 const setCommitQualityScore = ({ commit, commitType, diffObj }) => {
-  let qualityScore = 0;
+  const getCommitQualityScore = (commitType) => {
+    switch (commitType) {
+      case COMMIT_TYPE.remove.type:
+        return scoreRemoveCommitType(diffObj);
+      case COMMIT_TYPE.docs.type:
+        return scoreDocsCommitType(diffObj);
+      case COMMIT_TYPE.test.type:
+        return scoreTestCommitType(diffObj);
+      default:
+        return 0;
+    }
+  };
 
-  switch (commitType) {
-    case COMMIT_TYPE.remove.type: {
-      qualityScore = scoreRemoveCommitType(diffObj);
-      break;
-    }
-    case COMMIT_TYPE.docs.type: {
-      qualityScore = scoreDocsCommitType(diffObj);
-      break;
-    }
-    case COMMIT_TYPE.test.type: {
-      qualityScore = scoreTestCommitType(diffObj);
-      break;
-    }
-  }
-
-  commit.qualityScore = qualityScore;
+  commit.qualityScore = getCommitQualityScore(commitType);
 };
 
 export { createCommitEntity, makeCommitEntityWithDiff, setCommitQualityScore };

--- a/src/entities/commit/commitEntity.js
+++ b/src/entities/commit/commitEntity.js
@@ -1,6 +1,7 @@
 import COMMIT_TYPE from "./enum/commitTypeEnum";
 import scoreDocsCommitType from "./services/scoreDocsCommitType";
 import scoreRemoveCommitType from "./services/scoreRemoveCommitType";
+import scoreTestCommitType from "./services/scoreTestCommitType";
 
 /**
  * @param {{
@@ -46,6 +47,10 @@ const setCommitQualityScore = ({ commit, commitType, diffObj }) => {
     }
     case COMMIT_TYPE.docs.type: {
       qualityScore = scoreDocsCommitType(diffObj);
+      break;
+    }
+    case COMMIT_TYPE.test.type: {
+      qualityScore = scoreTestCommitType(diffObj);
       break;
     }
   }

--- a/src/entities/commit/services/scoreTestCommitType.js
+++ b/src/entities/commit/services/scoreTestCommitType.js
@@ -1,4 +1,4 @@
-const TEST_TYPE_FILENAME_EXTENSIONS = new Set(["test", "spec"]);
+const TEST_TYPE_FILENAME_EXTENSIONS = new Set(["test", "spec", "mock"]);
 
 /**
  * @param {Object} diffObj - 변경사항 객체

--- a/src/entities/commit/services/scoreTestCommitType.js
+++ b/src/entities/commit/services/scoreTestCommitType.js
@@ -1,0 +1,25 @@
+const TEST_TYPE_FILENAME_EXTENSIONS = new Set(["test", "spec"]);
+
+/**
+ * @param {Object} diffObj - 변경사항 객체
+ * @returns {number} commitScore - 최종 점수
+ */
+const scoreTestCommitType = (diffObj) => {
+  const passedFilesCount = Object.keys(diffObj).filter((filePath) => {
+    const fileName = filePath.slice(filePath.lastIndexOf("/") + 1);
+
+    const hasTestFileExtension = fileName
+      .split(".")
+      .some((name) => TEST_TYPE_FILENAME_EXTENSIONS.has(name));
+
+    return hasTestFileExtension;
+  }).length;
+
+  const commitScore = Math.floor(
+    (passedFilesCount / Object.keys(diffObj).length) * 100
+  );
+
+  return commitScore;
+};
+
+export default scoreTestCommitType;


### PR DESCRIPTION
# 이슈

🔗 이슈 링크 [#7](https://github.com/git-marvel/commit-guardians-client/issues/7)

# 요약

- test 커밋 타입인 경우의 커밋의 퀄리티 점수를 계산하는 로직입니다.


# 작업내용

- [x] 테스트 파일 확장자와 mock 데이터 파일을 확인한다. `.test` `.spec`, `.mock`
* 예시
```
.test.js, .test.ts, .test.tsx
.spec.js, .spec.ts, e2e.spec.ts, spec.cy.js 

*.mock.js, *.mock.json
```


# PR 체크 사항

## 주의 사항

- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!

---

## 리뷰 반영사항

- [ ]
