### PR TITLE
test: docs타입의 커밋 점수를 계산하는 함수(scoreDocsCommitType)의 테스트 코드 작성

### DIFF
--- a/src/entities/commit/services/__tests__/diffObj.mock.js
+++ b/src/entities/commit/services/__tests__/diffObj.mock.js
@@ -1,0 +1,68 @@
+const diffObj = {
+  allPassed: {
+    "a/pull_request_template.md": [
+      {
+        "+": "+# 작업 내용\n",
+        "-": "-# 칸반 링크\n",
+      },
+      {
+        "+": "+간단한 작업 내용과 칸반 태스크 링크를 추가해 주세요.\n",
+        "-": "-이 부분에 노션 칸반 링크 추가 해주세요\n",
+      },
+      {
+        "+": "+## 목업 UI 화면\n",
+        "-": "-# 목업 UI 화면 캡쳐\n",
+      },
+      {
+        "+": "+이 부분에 목업 UI 화면을 추가해 주세요.\n",
+        "-": "-이 부분에 목업 UI 화면을 추가해주세요\n",
+      },
+    ],
+    "a/docs/source/index.md": [
+      {
+        "-": "-\n",
+        "+": "",
+      },
+    ],
+  },
+  allFailed: {
+    "a/docs/source/use/using.rst": [
+      {
+        "+": '+\t\t\thref="../projects/kernels.html"]\n',
+        "-": '-\t\t\thref="../projects/kernels.html]\n',
+      },
+    ],
+  },
+  partialPassed: {
+    "a/README.md": [
+      {
+        "+": "+## Documentation structure\n+\n+This documentation uses the [Sphinx](https://sphinx-doc.org) documentation engine.\n+\n+Next, navigate to the `/docs` directory and create a `conda` environment:\n",
+        "-": "-## Running the docs locally\n-First navigate to the `/docs` directory and create a `conda` environment:\n",
+      },
+      {
+        "+": "+**Build the docs** using Sphinx with the following commands:\n",
+        "-": "-Build the docs:\n",
+      },
+    ],
+    "a/docs/source/conf.py": [
+      {
+        "+": "+panels_add_bootstrap_css = False\n",
+        "-": "-panels_add_boostrap_css = False\n",
+      },
+    ],
+    "a/docs/source/index.md": [
+      {
+        "-": "-\n",
+        "+": "",
+      },
+    ],
+    "a/noxfile.py": [
+      {
+        "+": '+import nox\n+\n+nox.options.reuse_existing_virtualenvs = True\n+\n+build_command = ["-b", "html", "docs/source", "docs/build/html"]\n+    session.run(*cmd)\n',
+        "-": "",
+      },
+    ],
+  },
+};
+
+export default diffObj;

--- a/src/entities/commit/services/__tests__/scoreDocsCommitType.test.js
+++ b/src/entities/commit/services/__tests__/scoreDocsCommitType.test.js
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import scoreDocsCommitType from "../scoreDocsCommitType";
+import diffObj from "./diffObj.mock";
+
+describe("scoreDocsCommitType", () => {
+  it("변경된 파일이 모두 문서 작업만을 했을 경우 100%의 점수를 반환해야 합니다.", () => {
+    expect(scoreDocsCommitType(diffObj.allPassed)).toBe(100);
+  });
+
+  it("변경된 파일이 모두 문서 작업 파일이 아닐 경우 0%의 점수를 반환해야 합니다.", () => {
+    expect(scoreDocsCommitType(diffObj.allFailed)).toBe(0);
+  });
+
+  it("여러 파일이 있는 경우 유효한 파일에 대해 계산한 점수를 반환해야 합니다.", () => {
+    expect(scoreDocsCommitType(diffObj.partialPassed)).toBe(50);
+  });
+
+  it("변경사항이 없는 경우 0%의 점수를 반환해야 합니다.", () => {
+    expect(scoreDocsCommitType({})).toBe(0);
+  });
+});

--- a/src/entities/commit/services/scoreDocsCommitType.js
+++ b/src/entities/commit/services/scoreDocsCommitType.js
@@ -15,6 +15,10 @@ const DOCS_TYPE_FILENAME_EXTENSIONS = [
  * @returns {number} commitScore - 최종 점수
  */
 const scoreDocsCommitType = (diffObj) => {
+  if (!diffObj || Object.keys(diffObj).length === 0) {
+    return 0;
+  }
+
   const passedFilesCount = Object.keys(diffObj).filter((filePath) => {
     return DOCS_TYPE_FILENAME_EXTENSIONS.some((extension) =>
       filePath.endsWith(extension)


### PR DESCRIPTION
# 이슈

🔗 이슈 링크 [#22](https://github.com/git-marvel/commit-guardians-client/issues/22)

# 요약

- docs타입의 커밋 점수를 계산하는 함수(scoreDocsCommitType)의 테스트 코드입니다.

# 작업내용

- [ ] 목업 생성하기
- [ ] 파일확장자 거르기 (.img, .png, .jpeg, .svg, . ai, .pdf, .docs, .md)
     * 문서작업을 할 때 사용되는 파일만이 점수로 계산됩니다.


# PR 체크 사항

## 주의 사항

- [ ] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [ ] conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [ ] 가장 최신 브랜치를 pull 하였습니다.
- [ ] base 브랜치명을 확인하였습니다.
- [ ] 코드 컨벤션을 모두 확인하였습니다.
- [ ] 브랜치명을 확인하였습니다.
- [ ] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!

---

## 리뷰 반영사항

- [ ]
