### PR TITLE
design: 막대그래프 최대값 제한 수정 및 홈 레이아웃 개선

### DIFF
--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -9,7 +9,7 @@ const Home = () => {
     useValidateCommit();
 
   return (
-    <div className="absolute top-0 m-10">
+    <div className="m-10">
       <GithubAPIStatus />
       <form method="post" onSubmit={handleCheckCommitQuality}>
         <label>

--- a/src/shared/components/BarGraph.jsx
+++ b/src/shared/components/BarGraph.jsx
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types";
 
-const MAX_WIDTH = 96;
+const MAX_WIDTH = 20;
 
 const BarGraph = ({ totalChanges, qualityScore }) => {
   const width = Math.min(totalChanges, MAX_WIDTH) * 10;


### PR DESCRIPTION
# 이슈

🔗 이슈 링크 x

# 요약

- 처음 막대그래프가 넘어가지 않도록 max 값을 설정해둔 상수를 조정하여, 레이아웃을 넘어가지 않도록 합니다.

# 구현화면
### [개선 전]
![image (1)](https://github.com/user-attachments/assets/b17db0bb-9dd3-4e2e-8991-5d199758c191)
### [개선 후]
![image](https://github.com/user-attachments/assets/ac34ef47-b182-45af-8a3c-a96eb9088f54)

# 작업내용

- [ ] 처음 막대그래프가 넘어가지 않도록 max 값을 설정해둔 상수를 조정하여, 레이아웃을 넘어가지 않도록 합니다.
- [ ] 홈화면이 길어도 잘리지 않게 레이아웃 개선합니다.

# 참고사항

x

# PR 체크 사항

## 주의 사항

- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] design 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.

---

## 리뷰 반영사항

- [ ]
