### PR TITLE
fix: commit author 가 null 일 경우 로직 및 화면 처리

### DIFF
--- a/src/entities/commit/services/index.js
+++ b/src/entities/commit/services/index.js
@@ -44,7 +44,7 @@ const getCheckableCommits = (totalCommits) => {
         url: commit.html_url,
         author: {
           ...commit.commit.author,
-          avatar_url: commit.author.avatar_url,
+          avatar_url: commit.author?.avatar_url,
         },
         message: commit.commit.message,
       });

--- a/src/features/commit/components/AvatarValue.jsx
+++ b/src/features/commit/components/AvatarValue.jsx
@@ -1,18 +1,17 @@
 import PropTypes from "prop-types";
 
-const AvatarValue = ({ author }) => {
-  if (!author.avatar_url) {
-    return null;
-  }
+const DEFAULT_IMG_URL =
+  "https://github.githubassets.com/assets/mona-loading-default-c3c7aad1282f.gif";
 
+const AvatarValue = ({ author }) => {
   return (
     <>
       <img
-        src={author.avatar_url}
+        src={author.avatar_url ?? DEFAULT_IMG_URL}
         alt="avatar_url"
         className="w-5 rounded-full"
       />
-      <p className="ml-2 text-sm text-slate-700">{author.name}</p>
+      <p className="ml-2 text-sm text-slate-700">{author.name ?? "unknown"}</p>
     </>
   );
 };

--- a/src/features/commit/components/AvatarValue.jsx
+++ b/src/features/commit/components/AvatarValue.jsx
@@ -1,6 +1,10 @@
 import PropTypes from "prop-types";
 
 const AvatarValue = ({ author }) => {
+  if (!author.avatar_url) {
+    return null;
+  }
+
   return (
     <>
       <img

--- a/src/features/commit/components/ChangesValue.jsx
+++ b/src/features/commit/components/ChangesValue.jsx
@@ -4,7 +4,9 @@ import FileIcon from "../../../shared/assets/svg/file-icon.svg";
 import BarGraph from "../../../shared/components/BarGraph";
 
 const ChangesValue = memo(({ commit }) => {
-  if (!commit.numOfFiles) return null;
+  if (!commit.numOfFiles) {
+    return null;
+  }
 
   return (
     <div className="flex">


### PR DESCRIPTION
# 이슈

🔗 이슈 링크 x

# 요약

- commit author 가 가끔 null 로 들어올 때가 있었다. 예시레포) [three.js](https://github.com/mrdoob/three)

# 작업내용

- [x] author 가 없는 경우, 아무것도 보여주지 않는 UI 를 작성했습니다.

# 참고사항
![image](https://github.com/user-attachments/assets/19611e0e-e153-4252-997f-a48aafb16a87)


# PR 체크 사항

## 주의 사항

- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.

## PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] avatar 브랜치명을 확인하였습니다.

---

## 리뷰 반영사항

- [ ]
