### PR TITLE
feat: github API status 가 정상이 아닌 경우는 버튼 클릭 차단 기능 추가

### DIFF
--- a/src/features/githubAPIStatus/api/index.js
+++ b/src/features/githubAPIStatus/api/index.js
@@ -1,11 +1,11 @@
 import axios from "axios";
 
-const GITHUB_STATUS_API_ADRESS =
+const GITHUB_STATUS_API_ADDRESS =
   "https://www.githubstatus.com/api/v2/status.json";
 
 const getGithubStatus = async () => {
   try {
-    const githubStatus = await axios.get(GITHUB_STATUS_API_ADRESS);
+    const githubStatus = await axios.get(GITHUB_STATUS_API_ADDRESS);
 
     return githubStatus.data.status.indicator;
   } catch {

--- a/src/features/githubAPIStatus/hooks/useGithubAPIStatus.jsx
+++ b/src/features/githubAPIStatus/hooks/useGithubAPIStatus.jsx
@@ -1,12 +1,18 @@
 import { useEffect, useState } from "react";
 import { getGithubStatus } from "../api";
+import useGithubStatusStore from "../store";
 
 const useGithubAPIStatus = () => {
   const [githubAPIStatusColor, setGithubAPIStatusColor] = useState("unknown");
+  const setGithubStatus = useGithubStatusStore(
+    (state) => state.setGithubStatus
+  );
 
   useEffect(() => {
     const storeGithubStatus = async () => {
       const githubAPIStatus = await getGithubStatus();
+
+      setGithubStatus(githubAPIStatus);
 
       const transferStatusColor = (githubAPIStatus) => {
         switch (githubAPIStatus) {
@@ -28,7 +34,7 @@ const useGithubAPIStatus = () => {
     };
 
     storeGithubStatus();
-  }, []);
+  }, [setGithubStatus]);
 
   return { githubAPIStatusColor };
 };

--- a/src/features/githubAPIStatus/store/index.js
+++ b/src/features/githubAPIStatus/store/index.js
@@ -1,0 +1,21 @@
+import { create } from "zustand";
+
+const initialState = {
+  githubStatus: "not yet",
+};
+
+const useGithubStatusStore = create((set) => ({
+  ...initialState,
+
+  setGithubStatus: (githubStatus) =>
+    set(() => ({
+      githubStatus: githubStatus,
+    })),
+
+  clearAll: () =>
+    set(() => ({
+      ...initialState,
+    })),
+}));
+
+export default useGithubStatusStore;

--- a/src/pages/Home/api/index.js
+++ b/src/pages/Home/api/index.js
@@ -26,7 +26,7 @@ const getCommitList = async ({ owner, repo }) => {
     const gitCommitFirstPage = await fetchWithAuth(
       `${commitListUrl}&page=${1}`
     );
-    const linkHeader = gitCommitFirstPage.headers["link"];
+    const linkHeader = gitCommitFirstPage.headers.link;
     const lastPageNumber = linkHeader
       ? parseInt(linkHeader.match(/&page=(\d+)>; rel="last"/)?.[1])
       : 1;

--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -1,5 +1,5 @@
-import GithubAPIStatus from "../../features/githubAPIStatus/components/GithubAPIStatus";
 import CommitQualityScore from "../../features/commit/components/CommitQualityScore";
+import GithubAPIStatus from "../../features/githubAPIStatus/components/GithubAPIStatus";
 import Button from "../../shared/components/Button";
 import Loading from "../../shared/components/Loading";
 import useValidateCommit from "./hooks/useValidateCommit";

--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -5,24 +5,31 @@ import Loading from "../../shared/components/Loading";
 import useValidateCommit from "./hooks/useValidateCommit";
 
 const Home = () => {
-  const { isLoading, errorMessage, commitList, handleCheckCommitQuality } =
-    useValidateCommit();
+  const {
+    isLoading,
+    errorMessage,
+    isGithubAPIHealthy,
+    commitList,
+    handleCheckCommitQuality,
+  } = useValidateCommit();
 
   return (
     <div className="m-10">
       <GithubAPIStatus />
-      <form method="post" onSubmit={handleCheckCommitQuality}>
-        <label>
-          <span className="text-slate-400">Repository URL</span>
-          <input
-            className="w-full"
-            name="repositoryURL"
-            placeholder="ex) https://github.com/git-marvel/commit-guardians-client"
-            required
-          />
-        </label>
-        <Button>커밋 퀄리티 확인하기</Button>
-      </form>
+      {isGithubAPIHealthy && (
+        <form method="post" onSubmit={handleCheckCommitQuality}>
+          <label>
+            <span className="text-slate-400">Repository URL</span>
+            <input
+              className="w-full"
+              name="repositoryURL"
+              placeholder="ex) https://github.com/git-marvel/commit-guardians-client"
+              required
+            />
+          </label>
+          <Button>커밋 퀄리티 확인하기</Button>
+        </form>
+      )}
       {errorMessage && <p className="text-red-500">{errorMessage}</p>}
       {isLoading && <Loading />}
       {commitList.map((commit, index) => (

--- a/src/shared/constants/index.js
+++ b/src/shared/constants/index.js
@@ -1,6 +1,7 @@
 const GITHUB_TOKEN = import.meta.env.VITE_GITHUB_TOKEN;
 
 const ERROR_MESSAGES = {
+  githubStatusError: "Github 상태가 원할하지 않습니다.",
   invalidURL:
     "적합하지 않은 URL입니다. [https://github.com/소유자이름/레포지토리이름/...] 혹은 [github.com/소유자이름/레포지토리이름/] 처럼 URL를 넣어주세요!",
   invalidGithubURL:

--- a/src/shared/error/throwCustomErrorMessage.js
+++ b/src/shared/error/throwCustomErrorMessage.js
@@ -7,8 +7,10 @@ const throwCustomErrorMessage = (error) => {
       throw new Error(ERROR_MESSAGES.rateLimitExceeded);
     case 404:
       throw new Error(ERROR_MESSAGES.invalidGithubURL);
-    default:
+    case 500:
       throw new Error(ERROR_MESSAGES.networkError);
+    default:
+      throw error;
   }
 };
 


### PR DESCRIPTION
# 이슈

🔗 이슈 링크 https://github.com/git-marvel/commit-guardians-client/pull/29

# 요약

- github API status 가 정상이 아닌 경우, repo 입력란과 버튼을 차단시킵니다.

# 작업내용

- [ ] github API status 가 정상이 아닌 경우, repo 입력란과 버튼을 차단시킵니다.
- [ ] errorMessage 를 추가했습니다.
- [ ] default 에러일 경우, error 가공하지 않고, 그대로 던집니다.

# 참고사항

# PR 체크 사항

## 주의 사항

- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] url-test 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!

---

## 리뷰 반영사항

- [ ]
