### PR TITLE
feat: style 체크 로직 작성

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "axios": "^1.7.7",
+    "diff-match-patch": "^1.0.5",
     "firebase": "^11.0.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/entities/commit/commitEntity.js
+++ b/src/entities/commit/commitEntity.js
@@ -1,6 +1,7 @@
 import COMMIT_TYPE from "./enum/commitTypeEnum";
 import scoreDocsCommitType from "./services/scoreDocsCommitType";
 import scoreRemoveCommitType from "./services/scoreRemoveCommitType";
+import scoreStyleCommitType from "./services/scoreStyleCommitType";
 import scoreTestCommitType from "./services/scoreTestCommitType";
 
 /**
@@ -54,6 +55,8 @@ const setCommitQualityScore = ({ commit, commitType, diffObj }) => {
         return scoreDocsCommitType(diffObj);
       case COMMIT_TYPE.test.type:
         return scoreTestCommitType(diffObj);
+      case COMMIT_TYPE.style.type:
+        return scoreStyleCommitType(diffObj);
       default:
         return 0;
     }

--- a/src/entities/commit/services/scoreStyleCommitType.js
+++ b/src/entities/commit/services/scoreStyleCommitType.js
@@ -1,0 +1,161 @@
+import DiffMatchPatch from "diff-match-patch";
+const STYLE_FILE_NAME_WORDS = ["prettier", "eslint", "config"];
+const CLASS_NAME_REGEX = /className="([^"]*)"/;
+const OBJECT_PARAMS_REGEX = /\{\s([^}]*)\s\}/;
+const SPECIAL_CHARS_REGEX = /^([;,'"\n\s]|\n[+-]|[+-]\n)*$/g;
+
+const isStyleFile = (filePath) => {
+  const fileName = filePath.split("/").pop().toLowerCase();
+
+  return STYLE_FILE_NAME_WORDS.some((word) => fileName.includes(word));
+};
+
+const containsConsoleLog = (string) => {
+  return string.includes("console.log");
+};
+
+const extractPattern = (text, pattern) => {
+  const match = text.match(pattern);
+  if (!match) {
+    return { extracted: "", remaining: text };
+  }
+
+  const extracted = match[1];
+  const remaining = text.replace(pattern, "").trim();
+
+  return { extracted, remaining };
+};
+
+const hasIdenticalClasses = ({ srtingAdded, srtingRemoved }) => {
+  const classAdded = extractPattern(srtingAdded, CLASS_NAME_REGEX);
+  const classRemoved = extractPattern(srtingRemoved, CLASS_NAME_REGEX);
+
+  if (classAdded.extracted === classRemoved.extracted) {
+    return {
+      identical: true,
+      srtingAdded: classAdded.remaining,
+      srtingRemoved: classRemoved.remaining,
+    };
+  }
+
+  const addClasses = new Set(classAdded.extracted.split(" "));
+  const removeClasses = classRemoved.extracted.split(" ");
+
+  const isIdentical =
+    removeClasses.every((className) => addClasses.has(className)) &&
+    addClasses.size === removeClasses.length;
+
+  return {
+    identical: isIdentical,
+    srtingAdded: classAdded.remaining,
+    srtingRemoved: classRemoved.remaining,
+  };
+};
+
+const hasIdenticalObjectParams = ({ srtingAdded, srtingRemoved }) => {
+  const objectAdded = extractPattern(srtingAdded, OBJECT_PARAMS_REGEX);
+  const objectRemoved = extractPattern(srtingRemoved, OBJECT_PARAMS_REGEX);
+
+  if (objectAdded.extracted === objectRemoved.extracted) {
+    return {
+      identical: true,
+      srtingAdded: objectAdded.remaining,
+      srtingRemoved: objectRemoved.remaining,
+    };
+  }
+
+  const addParams = new Set(objectAdded.extracted.split(", "));
+  const removeParams = objectRemoved.extracted.split(", ");
+
+  const isIdentical =
+    removeParams.every((param) => addParams.has(param)) &&
+    addParams.size === removeParams.length;
+
+  return {
+    identical: isIdentical,
+    srtingAdded: objectAdded.remaining,
+    srtingRemoved: objectRemoved.remaining,
+  };
+};
+
+const containsOnlySpecialChars = (text) => SPECIAL_CHARS_REGEX.test(text);
+
+const isStyleChange = (change) => {
+  const srtingAdded = change["+"].slice(1);
+  const srtingRemoved = change["-"].slice(1);
+  const dmp = new DiffMatchPatch();
+  const diffs = dmp
+    .diff_main(srtingAdded, srtingRemoved)
+    .filter(([type]) => type !== 0);
+
+  if (
+    diffs.every(
+      ([, text]) => containsOnlySpecialChars(text) || containsConsoleLog(text)
+    )
+  ) {
+    return true;
+  }
+
+  const classComparison = hasIdenticalClasses({ srtingAdded, srtingRemoved });
+  if (!classComparison.identical) {
+    return false;
+  }
+
+  const paramComparison = hasIdenticalObjectParams(classComparison);
+  if (!paramComparison.identical) {
+    return false;
+  }
+
+  const remainingDiffs = dmp
+    .diff_main(paramComparison.srtingAdded, paramComparison.srtingRemoved)
+    .filter(([type]) => type !== 0);
+
+  return remainingDiffs.every(
+    ([, text]) => containsOnlySpecialChars(text) || containsConsoleLog(text)
+  );
+};
+
+/**
+ * 파일별 삭제 점수를 계산하는 함수입니다.
+ * @param {Array} changes - 파일의 변경사항 목록
+ * @param {string} fileName - 파일 이름
+ * @returns {number} - 파일의 삭제 점수
+ */
+const calculateFileScore = (fileName, changes) => {
+  if (!changes.length) {
+    return 0;
+  }
+
+  if (isStyleFile(fileName)) {
+    return 100;
+  }
+
+  const validChanges = changes.reduce((count, change) => {
+    return isStyleChange(change) ? count + 1 : count;
+  }, 0);
+
+  return Math.floor((validChanges / changes.length) * 100);
+};
+
+/**
+ * style 커밋 타입의 변경사항을 검증하고 점수를 합계하고 평균을 내는 함수입니다.
+ * @param {Object} diffObj - 변경사항 객체
+ * @returns {number} - 최종 점수
+ */
+const scoreStyleCommit = (diffObj) => {
+  const fileEntries = Object.entries(diffObj).filter(
+    ([, changes]) => changes.length > 0
+  );
+
+  if (!fileEntries.length) {
+    return 0;
+  }
+
+  const totalScore = fileEntries.reduce((sum, [fileName, changes]) => {
+    return sum + calculateFileScore(fileName, changes);
+  }, 0);
+
+  return Math.floor(totalScore / fileEntries.length);
+};
+
+export default scoreStyleCommit;


### PR DESCRIPTION
# 이슈

🔗 이슈 링크: https://github.com/orgs/git-marvel/projects/1/views/1?pane=issue&itemId=85651858&issue=git-marvel%7Ccommit-guardians-client%7C6

# 요약
style 타입을 가지는 commit들의 점수를 계산하는 기능을 추가하였습니다.

# 구현화면
![image](https://github.com/user-attachments/assets/ed3559fc-eda5-40a0-8c52-47bfd762e350)


# 작업내용

- [x] 변경사항이 코드 포맷팅의 내용인지 체크하는 로직 구현

# 참고사항

## 구현 하지 못한 것

### 단순 변수명 변경

바뀐 단어가 단순 이름의 변경인지 사용하는 대상이 변경되어있는지 diff만으로 판단 불가능하다.

### 줄 바꿈

줄을 바꾸게 되면 다음과 같은 이슈가 발생한다.

- change가 하나로 묶이지 않는다. (change를 모두 저장해 놓고 문자열을 비교해야 해결 가능)
- scope가 변경된다면, 단순 style이 아니라 feat 혹은 refactor로 취급될 수 있는데, diff만으로 판단 불가능 하다.

### if문의 중괄호 사용

if문을 간단히 표시하기 위해 중괄호를 생략하고 작성하는 경우가 종종있는데, scope 제한이 명시적으로 되어있지 않아 원치않는 버그를 유발시킬 수 있다. 개인적으로는 refactor에 더 가깝다 생각하는데, style로 생각하면 생각할 수 있는 부분이다.

[[참고하면 좋은 글](https://stackoverflow.com/questions/2125066/is-it-a-bad-practice-to-use-an-if-statement-without-curly-braces)](https://stackoverflow.com/questions/2125066/is-it-a-bad-practice-to-use-an-if-statement-without-curly-braces)

## 구현 한 것

### 파일명에 style을 나타내는 단어가 있는 경우

"prettier", "eslint", "config”와 같은 단어가 파일명에 있는 경우 style을 통일화 하기 위한 파일의 변경으로 볼 수 있다. chore혹은 docs와 겹칠 수 있는 부분이지만, style로 보는게 적합하다 본다.

### style과 관련된 특수문자 수정

`,` , `'` , `"` , `\n` , `;` 과 같은 특수 문자만 변경이 있는 경우 올바르다고 채점 한다. 

Google의 diff-match-patch 패키지를 이용해서 문자열의 변화를 추출하고, 해당 변화가 조건에 맞는 변경만 있을 시에 true로 반환한다.

### `console.log` 확인

변경된 문자열이 `console.log` 과 관련된 경우 true로 반환

### 요소들의 위치 변경

아래와 같은 위치 변경에 대해 문자열을 추출하고 비교한다.

- tailwind 사용시 className안의 style 속성들의 위치 변경 `/className="([^"]*)"/`
- object의 property들의 위치 변경 `/\{\s([^}]*)\s\}/`

해당 추출된 문자열을 split하여 각 요소들을 리스트로 만들고, set을 이용하여 모두 일치 하는지 비교한다.

# PR 체크 사항

## 주의 사항

- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.

---

## 리뷰 반영사항

- [ ]
