### PR TITLE
feat: test 커밋타입 키워드 추가

### DIFF
--- a/src/entities/commit/services/scoreTestCommitType.js
+++ b/src/entities/commit/services/scoreTestCommitType.js
@@ -1,32 +1,28 @@
 const TEST_TYPE_VALIDATED_KEYWORDS = ["test", "tests", "spec", "mock"];
 
+const isTestFile = (partOfFileName) => {
+  return TEST_TYPE_VALIDATED_KEYWORDS.some((extension) =>
+    partOfFileName.endsWith(extension)
+  );
+};
+
 /**
  * @param {Object} diffObj - 변경사항 객체
  * @returns {number} commitScore - 최종 점수
  */
 const scoreTestCommitType = (diffObj) => {
-  const passedFilesCount = Object.keys(diffObj).filter((filePath) => {
-    const separatedFileNames = filePath
+  const totalFiles = Object.keys(diffObj);
+  const passedFilesCount = totalFiles.reduce((count, filePath) => {
+    const fileName = filePath
       .substring(filePath.lastIndexOf("/") + 1, filePath.lastIndexOf("."))
-      .toLowerCase()
-      .split(".");
+      .toLowerCase();
 
-    for (const name of separatedFileNames) {
-      const isTestType = TEST_TYPE_VALIDATED_KEYWORDS.some((extension) =>
-        name.endsWith(extension)
-      );
+    return isTestFile(fileName) || fileName.split(".").some(isTestFile)
+      ? count + 1
+      : count;
+  }, 0);
 
-      if (isTestType) {
-        return isTestType;
-      }
-    }
-
-    return false;
-  }).length;
-
-  const commitScore = Math.floor(
-    (passedFilesCount / Object.keys(diffObj).length) * 100
-  );
+  const commitScore = Math.floor((passedFilesCount / totalFiles.length) * 100);
 
   return commitScore;
 };

--- a/src/entities/commit/services/scoreTestCommitType.js
+++ b/src/entities/commit/services/scoreTestCommitType.js
@@ -1,4 +1,4 @@
-const TEST_TYPE_FILENAME_EXTENSIONS = new Set(["test", "spec", "mock"]);
+const TEST_TYPE_VALIDATED_KEYWORDS = ["test", "tests", "spec", "mock"];
 
 /**
  * @param {Object} diffObj - 변경사항 객체
@@ -6,13 +6,22 @@ const TEST_TYPE_FILENAME_EXTENSIONS = new Set(["test", "spec", "mock"]);
  */
 const scoreTestCommitType = (diffObj) => {
   const passedFilesCount = Object.keys(diffObj).filter((filePath) => {
-    const fileName = filePath.slice(filePath.lastIndexOf("/") + 1);
+    const separatedFileNames = filePath
+      .substring(filePath.lastIndexOf("/") + 1, filePath.lastIndexOf("."))
+      .toLowerCase()
+      .split(".");
 
-    const hasTestFileExtension = fileName
-      .split(".")
-      .some((name) => TEST_TYPE_FILENAME_EXTENSIONS.has(name));
+    for (const name of separatedFileNames) {
+      const isTestType = TEST_TYPE_VALIDATED_KEYWORDS.some((extension) =>
+        name.endsWith(extension)
+      );
 
-    return hasTestFileExtension;
+      if (isTestType) {
+        return isTestType;
+      }
+    }
+
+    return false;
   }).length;
 
   const commitScore = Math.floor(


### PR DESCRIPTION
# 이슈

🔗 이슈 링크 https://github.com/git-marvel/commit-guardians-client/issues/7

# 요약

- 판단 기준 확장
  - "tests" 키워드 추가
  - 통과 기준 수정: 파일명의 끝에 test커밋인지 판단하는 키워드가 포함되어 있다면 통과



# 작업내용

- [x] 파일 확장자와 앞 부분의 경로를 제외한 파일명에 test 커밋 검증 키워드가 포함되어 있는지 확인



# 참고사항

```
// 예시 (파일 확장자와 앞 부분의 경로를 제외)
".../auth_repository_imp_test.dart"  ->  auth_repository_imp_test
".../ResultServiceTest.java"  ->  ResultServiceTest
".../.../info_content.test.tsx.snap"  ->  info_content.test.tsx
```
* 잘라낸 파일명에 `"test", "tests", "spec", "mock"` 가 있는지 확인

# PR 체크 사항

## 주의 사항

- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!

---

## 리뷰 반영사항

- [ ]
