### PR TITLE
feat: docs 커밋 타입 파일 확장자에 .rst 추가

### DIFF
--- a/src/entities/commit/services/__tests__/diffObj.mock.js
+++ b/src/entities/commit/services/__tests__/diffObj.mock.js
@@ -28,7 +28,7 @@ const diffObj = {
   allFailed: {
     "a/scripts/utils/TemplateHelpers.ts": [
       {
-        "+": "+  return `\`${method.name}(${params})\``;",
+        "+": "+  return `\\`${method.name}(${params})\\``;",
         "-": "-  return `${method.name}(${params})`;",
       },
     ],

--- a/src/entities/commit/services/__tests__/diffObj.mock.js
+++ b/src/entities/commit/services/__tests__/diffObj.mock.js
@@ -26,10 +26,10 @@ const diffObj = {
     ],
   },
   allFailed: {
-    "a/docs/source/use/using.rst": [
+    "a/scripts/utils/TemplateHelpers.ts": [
       {
-        "+": '+\t\t\thref="../projects/kernels.html"]\n',
-        "-": '-\t\t\thref="../projects/kernels.html]\n',
+        "+": "+  return `\`${method.name}(${params})\``;",
+        "-": "-  return `${method.name}(${params})`;",
       },
     ],
   },

--- a/src/entities/commit/services/scoreDocsCommitType.js
+++ b/src/entities/commit/services/scoreDocsCommitType.js
@@ -2,6 +2,7 @@ const DOCS_TYPE_FILENAME_EXTENSIONS = [
   ".docs",
   ".md",
   ".mdx",
+  ".rst",
   ".img",
   ".png",
   ".jpeg",


### PR DESCRIPTION
# 이슈

🔗 이슈 링크 https://github.com/git-marvel/commit-guardians-client/issues/5

# 요약

- 테스트 코드 작업 중 문서작성 관련 추가 파일확장자(.rst)를 알게 되어 추가했습니다.


# 작업내용

- [x] docs type 파일 확장자에 `.rst` 추가

# 참고사항

- `.rst`

  - 주로 Python 커뮤니티에서 사용되는 기술 문서 파일 형식으로 reStructuredText 마크업 언어로 작성된 텍스트 파일의 확장자입니다. 
  - [reStructuredText documentation](https://docutils.sourceforge.io/rst.html#reference-documentation)
# PR 체크 사항

## 주의 사항

- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!

---

## 리뷰 반영사항

- [ ]
