### PR TITLE
test: scoreStyleCommitType 함수에 대한 test 코드 작성

### DIFF
--- a/src/entities/commit/services/__tests__/scoreStyleCommitType.test.js
+++ b/src/entities/commit/services/__tests__/scoreStyleCommitType.test.js
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import scoreStyleCommit from "../scoreStyleCommitType";
+
+describe("scoreStyleCommit", () => {
+  it("파일이름에 prettier가 포함된 경우 100점을 반환해야 합니다.", () => {
+    const diffObj = {
+      "prettierrc.json": [{ "-": "-deleted content" }],
+    };
+    expect(scoreStyleCommit(diffObj)).toBe(100);
+  });
+
+  it("파일이름에 eslint가 포함된 경우 100점을 반환해야 합니다.", () => {
+    const diffObj = {
+      "eslintrc.json": [{ "-": "-deleted content" }],
+    };
+    expect(scoreStyleCommit(diffObj)).toBe(100);
+  });
+
+  it("파일이름에 config가 포함된 경우 100점을 반환해야 합니다.", () => {
+    const diffObj = {
+      "postcss.config.json": [{ "-": "-deleted content" }],
+    };
+    expect(scoreStyleCommit(diffObj)).toBe(100);
+  });
+
+  it("변경된 문자열이 console과 관련된 내용뿐일 경우 100점을 반환해야 합니다.", () => {
+    const diffObj = {
+      "src/pages/Home/api/getCommitList.js": [
+        { "+": "+", "-": "-console.log(allCommits);" },
+      ],
+    };
+    expect(scoreStyleCommit(diffObj)).toBe(100);
+  });
+
+  it("변경된 문자열이 style과 관련된 특수문자뿐일 경우 100점을 반환해야 합니다.", () => {
+    const diffObj = {
+      "src/pages/Home/api/getCommitList.js": [
+        {
+          "+": `+<button type="submit">api 요청</button>;`,
+          "-": `-<button type="submit">api 요청</button>`,
+        },
+      ],
+    };
+    expect(scoreStyleCommit(diffObj)).toBe(100);
+  });
+
+  it("변경된 문자열이 tailwind className의 class들 순서만 변경했다면 100점을 반환해야 합니다", () => {
+    const diffObj = {
+      "src/pages/Home/api/getCommitList.js": [
+        {
+          "+": `+<div className="w-1/2 my-5">`,
+          "-": `-<div className="my-5 w-1/2">`,
+        },
+      ],
+    };
+    expect(scoreStyleCommit(diffObj)).toBe(100);
+  });
+
+  it("변경된 문자열이 객체 property들의 순서만 변경했다면 100점을 반환해야 합니다.", () => {
+    const diffObj = {
+      "src/pages/Home/api/getCommitList.js": [
+        {
+          "+": `+import { createJSONStorage, persist } from "zustand/middleware";`,
+          "-": `-import { persist, createJSONStorage } from "zustand/middleware";`,
+        },
+      ],
+    };
+    expect(scoreStyleCommit(diffObj)).toBe(100);
+  });
+
+  it("여러 파일에 대해 정확한 점수를 계산해야 합니다.", () => {
+    const diffObj = {
+      "file1.json": [{ "-": "-const a = 1", "+": "+const b = 1" }],
+      "file2.yaml": [
+        {
+          "+": `+<div className="w-1/2 my-5">`,
+          "-": `-<div className="my-5 w-1/2">`,
+        },
+      ],
+    };
+    expect(scoreStyleCommit(diffObj)).toBe(50);
+  });
+
+  it("변경사항이 없는 경우 0 점수를 반환해야 합니다.", () => {
+    const diffObj = {
+      "file1.json": [],
+      "file2.yaml": [],
+    };
+    expect(scoreStyleCommit(diffObj)).toBe(0);
+  });
+
+  it("모든 파일이 비어 있는 경우를 올바르게 처리해야 합니다.", () => {
+    const diffObj = {};
+    expect(scoreStyleCommit(diffObj)).toBe(0);
+  });
+});


### PR DESCRIPTION
# 이슈

🔗 이슈 링크: https://github.com/git-marvel/commit-guardians-client/pull/61

# 요약
커밋 타입 style 관련 로직에 대한 검증을 진행했습니다.

# 작업내용

- [x] 아래 참고사항에 있는 style 검사 로직에 대한 테스트
- [x] 변경사항이 없는 경우에 대한 테스트
- [x] 여러 파일에 대한 점수를 계산하는 테스트

# 참고사항

## 구현 한 것
### 파일명에 style을 나타내는 단어가 있는 경우
"prettier", "eslint", "config”와 같은 단어가 파일명에 있는 경우 style을 통일화 하기 위한 파일의 변경으로 볼 수 있다. chore혹은 docs와 겹칠 수 있는 부분이지만, style로 보는게 적합하다 본다.

### style과 관련된 특수문자 수정
, , ' , " , \n , ; 과 같은 특수 문자만 변경이 있는 경우 올바르다고 채점 한다.

Google의 diff-match-patch 패키지를 이용해서 문자열의 변화를 추출하고, 해당 변화가 조건에 맞는 변경만 있을 시에 true로 반환한다.

### console.log 확인
변경된 문자열이 console.log 과 관련된 경우 true로 반환

### 요소들의 위치 변경
아래와 같은 위치 변경에 대해 문자열을 추출하고 비교한다.

### tailwind 사용시 className안의 style 속성들의 위치 변경 /className="([^"]*)"/
object의 property들의 위치 변경 /\{\s([^}]*)\s\}/
해당 추출된 문자열을 split하여 각 요소들을 리스트로 만들고, set을 이용하여 모두 일치 하는지 비교한다.

# PR 체크 사항

## PR 전 체크리스트
- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.

---

## 리뷰 반영사항

- [ ]
