### PR TITLE
refactor: docs타입에 대한 로직 최적화

### DIFF
--- a/src/entities/commit/services/scoreDocsCommitType.js
+++ b/src/entities/commit/services/scoreDocsCommitType.js
@@ -11,24 +11,28 @@ const DOCS_TYPE_FILENAME_EXTENSIONS = [
   ".pdf",
 ];
 
+const isDocsFile = (filePath) => {
+  return DOCS_TYPE_FILENAME_EXTENSIONS.some((extension) =>
+    filePath.endsWith(extension)
+  );
+};
+
 /**
  * @param {Object} diffObj - 변경사항 객체
  * @returns {number} commitScore - 최종 점수
  */
 const scoreDocsCommitType = (diffObj) => {
-  if (!diffObj || Object.keys(diffObj).length === 0) {
+  const totalFiles = Object.keys(diffObj);
+
+  if (totalFiles.length === 0) {
     return 0;
   }
 
-  const passedFilesCount = Object.keys(diffObj).filter((filePath) => {
-    return DOCS_TYPE_FILENAME_EXTENSIONS.some((extension) =>
-      filePath.endsWith(extension)
-    );
-  }).length;
+  const passedFilesCount = totalFiles.reduce((count, filePath) => {
+    return isDocsFile(filePath) ? count + 1 : count;
+  }, 0);
 
-  const commitScore = Math.floor(
-    (passedFilesCount / Object.keys(diffObj).length) * 100
-  );
+  const commitScore = Math.floor((passedFilesCount / totalFiles.length) * 100);
 
   return commitScore;
 };


### PR DESCRIPTION
# 이슈

🔗 이슈 링크 https://github.com/git-marvel/commit-guardians-client/issues/5

# 요약

- docs타입에 대한 로직 최적화 (scoreDocsCommitType)


# 작업내용

- [x] 파일 확장자 체크 부분 함수로 분리
- [x] 중복 선언된 곳 변수로 선언

# PR 체크 사항

## 주의 사항

- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.

---

## 리뷰 반영사항

- [ ]
