### PR TITLE
feat: 총 점수를 화면에 보여주는 기능 및 commit total score 와 관련된 변수명 변경

### DIFF
--- a/src/entities/score/services/index.js
+++ b/src/entities/score/services/index.js
@@ -1,20 +1,18 @@
 /**
- * @param {Array} scoredCommitList - 점수가 매겨진 commit들의 목록
- * @returns {{ perfectCommitNumber: number, finalQualityPercent: number }}
+ * @param {Array} commitList - 점수가 매겨진 commit들의 목록
+ * @returns {{ numOfPerfectCommits: number, totalScore: number }}
  */
-const getTotalQualityPercent = (scoredCommitList) => {
-  const perfectCommitNumber = scoredCommitList.filter(
-    (scoredCommit) => scoredCommit.score === 100
+const getCommitSummary = (commitList) => {
+  const numOfPerfectCommits = commitList.filter(
+    (commit) => commit.qualityScore === 100
   ).length;
-  const totalQualityPercent = Math.floor(
-    (perfectCommitNumber / scoredCommitList.length) * 100
+  const totalQualityScore = Math.floor(
+    (numOfPerfectCommits / commitList.length) * 100
   );
-  const finalQualityPercent =
-    totalQualityPercent === 0 && perfectCommitNumber > 0
-      ? 1
-      : totalQualityPercent;
+  const totalScore =
+    totalQualityScore === 0 && numOfPerfectCommits > 0 ? 1 : totalQualityScore;
 
-  return { perfectCommitNumber, finalQualityPercent };
+  return { numOfPerfectCommits, totalScore };
 };
 
-export { getTotalQualityPercent };
+export { getCommitSummary };

--- a/src/features/commit/store/useCommitStore.js
+++ b/src/features/commit/store/useCommitStore.js
@@ -11,9 +11,9 @@ const initialState = {
     numOfCommit: null,
     totalNumOfCommit: null,
   },
-  scoredCommitInfo: {
-    perfectCommitNumber: null,
-    finalQualityPercent: null,
+  commitSummary: {
+    numOfPerfectCommits: null,
+    totalScore: null,
   },
 };
 
@@ -48,9 +48,9 @@ const useCommitStore = create(
           },
         })),
 
-      setScoredCommitInfo: (newScoredCommitInfo) =>
+      setCommitSummary: (summaryObj) =>
         set(() => ({
-          scoredCommitInfo: newScoredCommitInfo,
+          commitSummary: summaryObj,
         })),
 
       clearAll: () =>

--- a/src/features/commitBadge/hooks/useCopyBadge.jsx
+++ b/src/features/commitBadge/hooks/useCopyBadge.jsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import useCommitStore from "../../commit/store/useCommitStore";
 import { getBadgeUrl } from "../services";
 
 const COPIED_DURATION_MS = 2000;
@@ -7,11 +8,12 @@ const useCopiedBadge = () => {
   const [badgeTagUrl, setBadgeTagUrl] = useState(null);
   const [isCopied, setIsCopied] = useState(false);
   const [error, setError] = useState(null);
+  const totalScore = useCommitStore((state) => state.commitSummary.totalScore);
 
   useEffect(() => {
     const fetchBadgeUrl = async () => {
       try {
-        const svgUrl = await getBadgeUrl({ qualityPercent: 100 });
+        const svgUrl = await getBadgeUrl({ totalScore });
 
         setBadgeTagUrl(svgUrl);
       } catch (err) {
@@ -20,7 +22,7 @@ const useCopiedBadge = () => {
     };
 
     fetchBadgeUrl();
-  }, []);
+  }, [totalScore]);
 
   const copyBadgeTag = useCallback(async () => {
     try {

--- a/src/features/commitBadge/services/index.js
+++ b/src/features/commitBadge/services/index.js
@@ -1,14 +1,14 @@
 import { getDownloadURL, ref } from "firebase/storage";
 import { storage } from "../../../shared/config";
 
-const getBadgeUrl = async ({ qualityPercent }) => {
+const getBadgeUrl = async ({ totalScore }) => {
   let fileRef;
 
-  if (qualityPercent >= 80) {
+  if (totalScore >= 80) {
     fileRef = ref(storage, "badges/commit-rulemaster-style-01.svg");
-  } else if (qualityPercent >= 50) {
+  } else if (totalScore >= 50) {
     fileRef = ref(storage, "badges/commit-hardworker-style-02.svg");
-  } else if (qualityPercent >= 30) {
+  } else if (totalScore >= 30) {
     fileRef = ref(storage, "badges/commit-newbie-style-03.svg");
   } else {
     fileRef = ref(storage, "badges/commit-myway-style-04.svg");

--- a/src/pages/Home/hooks/useValidateCommit.jsx
+++ b/src/pages/Home/hooks/useValidateCommit.jsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { setCommitQualityScore } from "../../../entities/commit/commitEntity";
 import { getCheckableCommits } from "../../../entities/commit/services";
+import { getCommitSummary } from "../../../entities/score/services";
 import useCommitStore from "../../../features/commit/store/useCommitStore";
 import useGithubStatusStore from "../../../features/githubAPIStatus/store";
 import { ERROR_MESSAGES } from "../../../shared/constants";
@@ -19,6 +20,7 @@ const useValidateCommit = () => {
   const setTotalNumOfCommit = useCommitStore(
     (state) => state.setTotalNumOfCommit
   );
+  const setCommitSummary = useCommitStore((state) => state.setCommitSummary);
   const githubStatus = useGithubStatusStore((state) => state.githubStatus);
 
   const shouldNavigate = useMemo(
@@ -63,8 +65,11 @@ const useValidateCommit = () => {
       });
 
       setCommitList(commitWithDiff);
+
+      const totalCommitQualityInfo = getCommitSummary(commitWithDiff);
+      setCommitSummary(totalCommitQualityInfo);
     },
-    [setCommitList, setTotalNumOfCommit]
+    [setCommitList, setCommitSummary, setTotalNumOfCommit]
   );
 
   const handleCheckCommitQuality = useCallback(

--- a/src/pages/MyCommitBadge/index.jsx
+++ b/src/pages/MyCommitBadge/index.jsx
@@ -8,20 +8,31 @@ import HomeButton from "../../shared/components/HomeButton";
 const MyCommitBadge = () => {
   const navigate = useNavigate();
   const handleRoutingCommitScoreboard = () => navigate("/my-commit-scoreboard");
+  const numOfPerfectCommits = useCommitStore(
+    (state) => state.commitSummary.numOfPerfectCommits
+  );
   const totalScore = useCommitStore((state) => state.commitSummary.totalScore);
   const numOfCommit = useCommitStore((state) => state.commitInfo.numOfCommit);
 
   return (
     <div className="h-screen w-screen bg-gray-100">
-      <div className="m-4 flex flex-row items-center justify-start px-12 py-5">
+      <div className="m-4 flex flex-row items-center justify-start px-10 py-5">
         <HomeButton />
       </div>
       <div className="flex flex-col items-center justify-center">
+        {numOfPerfectCommits && (
+          <div className="mb-10 flex items-center font-bold text-slate-500">
+            <span className="mr-1 text-2xl text-sky-300">
+              {numOfPerfectCommits}
+            </span>
+            <span className="text-sm text-slate-300">commits</span>
+          </div>
+        )}
         {totalScore && (
           <>
-            <p className="font-bold text-slate-500">Total</p>
-            <h1 className="p-4 text-4xl font-bold text-blue-400">
-              {totalScore}
+            <p className="font-bold text-slate-500">Total Score</p>
+            <h1 className="mb-4 px-4 text-4xl font-bold text-blue-400">
+              + {totalScore}
             </h1>
           </>
         )}

--- a/src/pages/MyCommitBadge/index.jsx
+++ b/src/pages/MyCommitBadge/index.jsx
@@ -8,9 +8,7 @@ import HomeButton from "../../shared/components/HomeButton";
 const MyCommitBadge = () => {
   const navigate = useNavigate();
   const handleRoutingCommitScoreboard = () => navigate("/my-commit-scoreboard");
-  const perfectCommitNumber = useCommitStore(
-    (state) => state.scoredCommitInfo.perfectCommitNumber
-  );
+  const totalScore = useCommitStore((state) => state.commitSummary.totalScore);
   const numOfCommit = useCommitStore((state) => state.commitInfo.numOfCommit);
 
   return (
@@ -19,11 +17,11 @@ const MyCommitBadge = () => {
         <HomeButton />
       </div>
       <div className="flex flex-col items-center justify-center">
-        {perfectCommitNumber && (
+        {totalScore && (
           <>
             <p className="font-bold text-slate-500">Total</p>
             <h1 className="p-4 text-4xl font-bold text-blue-400">
-              {perfectCommitNumber}
+              {totalScore}
             </h1>
           </>
         )}


### PR DESCRIPTION
# 이슈

🔗 이슈 링크 https://github.com/git-marvel/commit-guardians-client/issues/71

# 요약

- 총 점수를 화면에 보여주는 기능이 있습니다.
- commit total score 와 관련있는 변수명들을 직관적으로 바꾸었습니다.

# 작업내용

- [x] `scoredCommitList` -> `commitList`
- [x] `perfectCommitNumber` -> `numOfPerfectCommits`,
- [x] `finalQualityPercent` -> `totalScore`,
- [x] `getTotalQualityPercent` -> `getCommitSummary`,

# 참고사항

- 변수명을 확인해주세요.

# PR 체크 사항

## 주의 사항

- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] rename 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.

---

## 리뷰 반영사항
