### PR TITLE
design: 디테일 페이지에 대한 디자인 수정 (github API status 링크로 이동, 정갈한 디자인)

### DIFF
--- a/src/features/commit/components/CommitQualityScore.jsx
+++ b/src/features/commit/components/CommitQualityScore.jsx
@@ -5,7 +5,7 @@ const CommitQualityScore = ({ qualityScore }) => {
     <p
       className={`w-20 rounded py-1 text-base font-bold ${qualityScore === 100 && qualityScore !== 0 ? "text-sky-400" : "text-black-900"} ${qualityScore === 0 && "text-slate-300"} `}
     >
-      {qualityScore === 100 ? `${qualityScore}점 🎉` : `${qualityScore}점`}
+      {qualityScore}
     </p>
   );
 };

--- a/src/features/commitBadge/hooks/useCopyBadge.jsx
+++ b/src/features/commitBadge/hooks/useCopyBadge.jsx
@@ -17,7 +17,7 @@ const useCopiedBadge = () => {
 
         setBadgeTagUrl(svgUrl);
       } catch (err) {
-        setError(`뱃지 불러오기를 실패했네요..🥲, ${err}`);
+        setError(`Fail to fetch the Badge..🥲, ${err}`);
       }
     };
 
@@ -41,7 +41,7 @@ const useCopiedBadge = () => {
 
       return badgeTag;
     } catch (error) {
-      setError(`뱃지 복사를 실패했네요..🥲, ${error}`);
+      setError(`Fail to copy the Badge..🥲, ${error}`);
     }
   }, [badgeTagUrl]);
 

--- a/src/features/githubAPIStatus/components/GithubAPIStatus.jsx
+++ b/src/features/githubAPIStatus/components/GithubAPIStatus.jsx
@@ -1,15 +1,19 @@
 import useGithubAPIStatus from "../hooks/useGithubAPIStatus";
 
+const GITHUB_STATUS_ADDRESS = "https://www.githubstatus.com";
+
 const GithubAPIStatus = () => {
   const { githubAPIStatusColor } = useGithubAPIStatus();
 
   return (
-    <div className="flex cursor-pointer items-center rounded-full border bg-slate-50 px-4 py-1">
-      <p className="pr-2 text-sm text-slate-400">GitHub API Status</p>
-      <div
-        className={`h-4 w-4 rounded-full border ${githubAPIStatusColor}`}
-      ></div>
-    </div>
+    <a href={GITHUB_STATUS_ADDRESS} target="_blank">
+      <div className="flex items-center rounded-full border bg-slate-50 px-4 py-1">
+        <p className="pr-2 text-sm text-slate-400">GitHub API Status</p>
+        <div
+          className={`h-4 w-4 rounded-full border ${githubAPIStatusColor}`}
+        ></div>
+      </div>
+    </a>
   );
 };
 

--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -16,7 +16,7 @@ const Home = () => {
 
   return (
     <div className="h-screen w-screen bg-gray-100">
-      <div className="m-4 flex flex-row items-center justify-end px-12 py-5">
+      <div className="m-4 flex flex-row items-center justify-end px-10 py-5">
         <GithubAPIStatus />
       </div>
       <div className="flex flex-col items-center justify-center">

--- a/src/pages/MyCommitScoreboard/components/ScoreBoardRow.jsx
+++ b/src/pages/MyCommitScoreboard/components/ScoreBoardRow.jsx
@@ -5,7 +5,6 @@ import CommitMessageValue from "../../../features/commit/components/CommitMessag
 import CommitQualityScore from "../../../features/commit/components/CommitQualityScore";
 import CommitTypeValue from "../../../features/commit/components/CommitTypeValue";
 import SHAValue from "../../../features/commit/components/SHAValue";
-import formatDate from "../../../shared/utils/formatDate";
 
 const ScoreBoardRow = ({ gridCols, commit }) => {
   return (
@@ -28,7 +27,10 @@ const ScoreBoardRow = ({ gridCols, commit }) => {
         <AvatarValue author={commit.author} />
       </div>
       <div className="col-span-2 px-2 py-1 text-sm">
-        {formatDate(commit.author.date)}
+        <p>{new Date(commit.author.date).toDateString()}</p>
+        <span className="text-xs text-slate-400">
+          {new Date(commit.author.date).toTimeString()}
+        </span>
       </div>
       <div className="col-span-1 px-2 py-1">
         <SHAValue sha={commit.sha} />

--- a/src/pages/MyCommitScoreboard/index.jsx
+++ b/src/pages/MyCommitScoreboard/index.jsx
@@ -12,7 +12,7 @@ const MyCommitScoreboard = () => {
 
   return (
     <>
-      <div className="m-4 flex w-full flex-row items-center justify-between px-12 py-5">
+      <div className="m-4 flex w-full flex-row items-center justify-between px-10 py-5">
         <div className="flex flex-row items-center">
           <HomeButton />
           <RepositoryLinkTag />

--- a/src/shared/components/Footer.jsx
+++ b/src/shared/components/Footer.jsx
@@ -10,7 +10,7 @@ const Footer = () => {
       >
         <h2 className="m-1 text-center text-sm">
           We are commit guardians!
-          <p className="text-blue-700">Team @git-marvel</p>
+          <p className="text-yellow-500">Team @git-marvel</p>
         </h2>
       </a>
       <div className="text-s mb-8 mt-2 flex">
@@ -36,7 +36,7 @@ const GithubNameButton = ({ name, githubUrl }) => {
     <a
       href={githubUrl}
       target="_blank"
-      className="mb-2 me-2 flex rounded-full border border-gray-300 bg-white px-2 py-1 text-sm font-medium text-slate-500 hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-100 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:hover:border-gray-600 dark:hover:bg-gray-700 dark:focus:ring-gray-700"
+      className="mb-2 me-2 flex rounded-full border border-gray-300 bg-white px-2 py-1 text-xs font-medium text-slate-500 hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-100 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:hover:border-gray-600 dark:hover:bg-gray-700 dark:focus:ring-gray-700"
     >
       <h2 className="m-1 text-sm">{name}</h2>
       <img


### PR DESCRIPTION
# 이슈

🔗 이슈 링크

# 요약

- 디테일 페이지에 대한 디자인 수정 (github API status 링크로 이동, 정갈한 디자인)

# 작업내용

- [x] github API status 버튼 클릭시 링크로 이동합니다.
- [x] 정갈한 UI 디자인에 맞추어, 폭죽등의 재미스러운 icon 은 삭제합니다.
- [x] date 에 time 도 보여줍니다.

# 참고사항

- 없습니다.

# PR 체크 사항

## 주의 사항

- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] minor-css 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.


---

## 리뷰 반영사항

- [ ]
