### PR TITLE
fix: 템플릿 형식 커밋과 GitMoji 사용시,  타입검사가 불가능했던 버그 해결

### DIFF
--- a/src/entities/commit/services/index.js
+++ b/src/entities/commit/services/index.js
@@ -2,7 +2,11 @@ import { createCommitEntity } from "../commitEntity";
 import COMMIT_FORMAT_STYLE from "../enum/commitFormatStyleEnum";
 import COMMIT_TYPE from "../enum/commitTypeEnum";
 
-const removeParentheses = (string) => string.replace(/\(.*\)$/, "");
+const EMOJI_REGEX =
+  /([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g;
+
+const removeEmoji = (string) => string.replace(EMOJI_REGEX, "");
+const removeSpecialCharacters = (string) => string.replace(/[^a-zA-Z]/g, "");
 
 /**
  * @param {string} firstWordOfCommitMessage
@@ -14,7 +18,7 @@ const makeCommitTypeWithFormatStyle = (firstWordOfCommitMessage) => {
   );
 
   const commitTypeString = formatStyle
-    ? removeParentheses(
+    ? removeSpecialCharacters(
         firstWordOfCommitMessage.split(formatStyle.splitWith)[0]
       )
         .trim()
@@ -34,7 +38,8 @@ const makeCommitTypeWithFormatStyle = (firstWordOfCommitMessage) => {
  */
 const getCheckableCommits = (totalCommits) => {
   const checkableCommits = totalCommits.reduce((accumulators, commit) => {
-    const firstWord = commit.commit.message.split(" ")[0];
+    const commitMessage = removeEmoji(commit.commit.message).trim();
+    const firstWord = commitMessage.split(" ")[0];
     const commitType = makeCommitTypeWithFormatStyle(firstWord);
 
     if (commitType !== undefined) {


### PR DESCRIPTION
# 이슈

🔗 이슈 링크 https://github.com/git-marvel/commit-guardians-client/issues/74

# 요약

- 템플릿 형식 커밋과 깃모지 사용시에도 문제 없이 서비스 사용할 수 있도록 버그를 해결했습니다.

# 작업내용

- [x] “[Feat] 로그인 구현“ 라는 템플릿 기반 커밋형식의 경우, 현재 타입으로 검증이 안되는 부분을 해결했습니다.
- [x] 깃모지도 제거하여 타입조사 가능하도록 했습니다.

# 참고사항

- [x]  문제원인 추적 1) `[Feat]` 이라면, 추적이 `[Feat` 으로 추출되기 때문이었다. → 알파벳만 추출하도록 수정
- [x]  추척 2) 이모지들 제거 : [[이모지 제거 정규식](https://mhui123.tistory.com/43)](https://mhui123.tistory.com/43)

# PR 체크 사항

## 주의 사항

- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] bracket 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.

---

## 리뷰 반영사항

- [ ]
