### PR TITLE
feat: 총 점수의 계산 방식 변경

### DIFF
--- a/src/entities/score/services/index.js
+++ b/src/entities/score/services/index.js
@@ -3,15 +3,16 @@
  * @returns {{ numOfPerfectCommits: number, totalScore: number }}
  */
 const getCommitSummary = (commitList) => {
-  let numOfPerfectCommits = 0;
-  let totalScoreSum = 0;
-
-  commitList.forEach((commit) => {
-    if (commit.qualityScore === 100) {
-      numOfPerfectCommits++;
-    }
-    totalScoreSum += commit.qualityScore;
-  });
+  const { numOfPerfectCommits, totalScoreSum } = commitList.reduce(
+    (acc, commit) => {
+      if (commit.qualityScore === 100) {
+        acc.numOfPerfectCommits++;
+      }
+      acc.totalScoreSum += commit.qualityScore;
+      return acc;
+    },
+    { numOfPerfectCommits: 0, totalScoreSum: 0 }
+  );
 
   const totalQualityScore = Math.floor(totalScoreSum / commitList.length);
   const totalScore =

--- a/src/entities/score/services/index.js
+++ b/src/entities/score/services/index.js
@@ -3,12 +3,17 @@
  * @returns {{ numOfPerfectCommits: number, totalScore: number }}
  */
 const getCommitSummary = (commitList) => {
-  const numOfPerfectCommits = commitList.filter(
-    (commit) => commit.qualityScore === 100
-  ).length;
-  const totalQualityScore = Math.floor(
-    (numOfPerfectCommits / commitList.length) * 100
-  );
+  let numOfPerfectCommits = 0;
+  let totalScoreSum = 0;
+
+  commitList.forEach((commit) => {
+    if (commit.qualityScore === 100) {
+      numOfPerfectCommits++;
+    }
+    totalScoreSum += commit.qualityScore;
+  });
+
+  const totalQualityScore = Math.floor(totalScoreSum / commitList.length);
   const totalScore =
     totalQualityScore === 0 && numOfPerfectCommits > 0 ? 1 : totalQualityScore;
 


### PR DESCRIPTION
# 이슈

🔗 이슈 링크 : https://github.com/git-marvel/commit-guardians-client/issues/69

# 요약

점수의 계산 방식을 100점 commit의 비율이 아닌, commit 점수들의 평균으로 변경하였습니다.

# 작업내용

- [x] 계산 로직 변경

# 참고사항


# PR 체크 사항

## PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.

---

## 리뷰 반영사항

- [x] forEach 대신 reduce사용
