### PR TITLE
feat: 커밋 formatStyle 도 디테일 화면에서 보여주기

### DIFF
--- a/src/entities/commit/commitEntity.js
+++ b/src/entities/commit/commitEntity.js
@@ -27,12 +27,12 @@ const createCommitEntity = ({
   message,
 }) => {
   return {
-    formatStyle: formatStyle,
-    type: type,
-    sha: sha,
-    url: url,
-    message: message,
-    author: author,
+    formatStyle,
+    type,
+    sha,
+    url,
+    message,
+    author,
     diffObj: null,
     numOfFiles: null,
     numOfChanges: null,

--- a/src/entities/commit/commitEntity.js
+++ b/src/entities/commit/commitEntity.js
@@ -6,6 +6,7 @@ import scoreTestCommitType from "./services/scoreTestCommitType";
 
 /**
  * @param {{
+ * formatStyle: COMMIT_FORMAT_STYLE.type,
  * type: COMMIT_TYPE.type,
  * sha: string,
  * url: string,
@@ -17,8 +18,16 @@ import scoreTestCommitType from "./services/scoreTestCommitType";
  * qualityScore: number,
  * }}
  */
-const createCommitEntity = ({ type, sha, url, author, message }) => {
+const createCommitEntity = ({
+  formatStyle,
+  type,
+  sha,
+  url,
+  author,
+  message,
+}) => {
   return {
+    formatStyle: formatStyle,
     type: type,
     sha: sha,
     url: url,

--- a/src/features/commit/components/CommitFormatStyleValue.jsx
+++ b/src/features/commit/components/CommitFormatStyleValue.jsx
@@ -1,0 +1,40 @@
+import PropTypes from "prop-types";
+import useCheckCommitFormatStyle from "../hooks/useCheckCommitFormatStyle";
+
+const CommitFormatStyleValue = () => {
+  const formatStyleAndRate = useCheckCommitFormatStyle();
+
+  const sortedFormatStyleAndRate = Object.entries(formatStyleAndRate).sort(
+    (a, b) => parseFloat(b[1]) - parseFloat(a[1])
+  );
+
+  return (
+    <div className="flex flex-row">
+      {sortedFormatStyleAndRate.map(([formatStyle, percent]) => (
+        <OneCommitFormatStyle
+          key={formatStyle}
+          formatStyle={formatStyle}
+          percent={percent}
+        />
+      ))}
+    </div>
+  );
+};
+
+const OneCommitFormatStyle = ({ formatStyle, percent }) => {
+  return (
+    <p className="flex w-fit cursor-default flex-row items-center rounded-full px-3 py-0.5 text-sm font-medium text-blue-500 transition duration-300 ease-in-out hover:fill-slate-800 hover:text-blue-900">
+      <span className="rounded-full border border-blue-200 px-1.5 py-0.5 text-xs text-blue-500">
+        {percent}
+      </span>
+      <span className="ml-1">{formatStyle}</span>
+    </p>
+  );
+};
+
+OneCommitFormatStyle.propTypes = {
+  formatStyle: PropTypes.string.isRequired,
+  percent: PropTypes.string.isRequired,
+};
+
+export default CommitFormatStyleValue;

--- a/src/features/commit/components/CommitFormatStyleValue.jsx
+++ b/src/features/commit/components/CommitFormatStyleValue.jsx
@@ -2,11 +2,7 @@ import PropTypes from "prop-types";
 import useCheckCommitFormatStyle from "../hooks/useCheckCommitFormatStyle";
 
 const CommitFormatStyleValue = () => {
-  const formatStyleAndRate = useCheckCommitFormatStyle();
-
-  const sortedFormatStyleAndRate = Object.entries(formatStyleAndRate).sort(
-    (a, b) => parseFloat(b[1]) - parseFloat(a[1])
-  );
+  const sortedFormatStyleAndRate = useCheckCommitFormatStyle();
 
   return (
     <div className="flex flex-row">

--- a/src/features/commit/components/CommitMessageValue.jsx
+++ b/src/features/commit/components/CommitMessageValue.jsx
@@ -1,13 +1,15 @@
 import PropTypes from "prop-types";
 
 const CommitMessageValue = ({ commit }) => {
+  const commitMessageTitle = commit.message.split("\n")[0];
+
   return (
     <a
       href={commit.url}
       target="_blank"
       className="group relative w-full font-semibold"
     >
-      <p>{commit.message}</p>
+      <p>{commitMessageTitle}</p>
       <p className="absolute right-0 w-fit -translate-y-full rounded-full border border-slate-300 bg-white px-2 py-1 text-xs text-slate-800 opacity-0 shadow-sm transition duration-300 ease-in-out group-hover:opacity-100">
         👈 링크로 이동
       </p>
@@ -16,7 +18,10 @@ const CommitMessageValue = ({ commit }) => {
 };
 
 CommitMessageValue.propTypes = {
-  commit: PropTypes.object.isRequired,
+  commit: PropTypes.shape({
+    message: PropTypes.string.isRequired,
+    url: PropTypes.string.isRequired,
+  }).isRequired,
 };
 
 export default CommitMessageValue;

--- a/src/features/commit/hooks/useCheckCommitFormatStyle.jsx
+++ b/src/features/commit/hooks/useCheckCommitFormatStyle.jsx
@@ -1,0 +1,25 @@
+import useCommitStore from "../../../features/commit/store/useCommitStore";
+
+const useCheckCommitFormatStyle = () => {
+  const numOfCommit = useCommitStore((state) => state.commitInfo.numOfCommit);
+  const commitFormatStyle = useCommitStore(
+    (state) => state.commitInfo.commitFormatStyle
+  );
+
+  const formatStyleAndRate = Object.entries(commitFormatStyle).reduce(
+    (acc, [formatStyle, count]) => {
+      if (count === 0) {
+        return acc;
+      }
+
+      const rate = Math.round((count / numOfCommit) * 100);
+      acc[formatStyle] = `${rate}%`;
+      return acc;
+    },
+    {}
+  );
+
+  return formatStyleAndRate;
+};
+
+export default useCheckCommitFormatStyle;

--- a/src/features/commit/hooks/useCheckCommitFormatStyle.jsx
+++ b/src/features/commit/hooks/useCheckCommitFormatStyle.jsx
@@ -19,7 +19,11 @@ const useCheckCommitFormatStyle = () => {
     {}
   );
 
-  return formatStyleAndRate;
+  const sortedFormatStyleAndRate = Object.entries(formatStyleAndRate).sort(
+    (a, b) => parseFloat(b[1]) - parseFloat(a[1])
+  );
+
+  return sortedFormatStyleAndRate;
 };
 
 export default useCheckCommitFormatStyle;

--- a/src/features/commit/store/useCommitStore.js
+++ b/src/features/commit/store/useCommitStore.js
@@ -8,6 +8,7 @@ const initialState = {
   },
   commitInfo: {
     commitList: [],
+    commitFormatStyle: {},
     numOfCommit: null,
     totalNumOfCommit: null,
   },
@@ -37,6 +38,14 @@ const useCommitStore = create(
             ...state.commitInfo,
             commitList: newCommitList,
             numOfCommit: newCommitList.length,
+          },
+        })),
+
+      setCommitFormatStyle: (commitFormatStyleObj) =>
+        set((state) => ({
+          commitInfo: {
+            ...state.commitInfo,
+            commitFormatStyle: commitFormatStyleObj,
           },
         })),
 

--- a/src/features/repository/components/RepositoryLinkTag.jsx
+++ b/src/features/repository/components/RepositoryLinkTag.jsx
@@ -7,12 +7,11 @@ const RepositoryLinkTag = () => {
     <a
       href={`https://github.com/${repository.owner}/${repository.repo}`}
       target="_blank"
+      className="rounded-lg px-3 py-1 text-slate-700 transition duration-300 ease-in-out hover:text-sky-600 dark:text-slate-200 dark:hover:text-sky-200"
     >
       <span>{repository.owner}</span>
-      <span className="px-2 font-black text-sky-300">/</span>
-      <span className="text-lg font-semibold text-slate-800">
-        {repository.repo}
-      </span>
+      <span className="px-2 font-black text-blue-300">/</span>
+      <span className="text-lg font-semibold">{repository.repo}</span>
     </a>
   );
 };

--- a/src/pages/Home/hooks/useValidateCommit.jsx
+++ b/src/pages/Home/hooks/useValidateCommit.jsx
@@ -1,7 +1,10 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { setCommitQualityScore } from "../../../entities/commit/commitEntity";
-import { getCheckableCommits } from "../../../entities/commit/services";
+import {
+  getCheckableCommits,
+  getFormatStyleAndRate,
+} from "../../../entities/commit/services";
 import { getCommitSummary } from "../../../entities/score/services";
 import useCommitStore from "../../../features/commit/store/useCommitStore";
 import useGithubStatusStore from "../../../features/githubAPIStatus/store";
@@ -15,8 +18,11 @@ const useValidateCommit = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [isGithubAPIHealthy, setGithubAPIHealthy] = useState(false);
   const [errorMessage, setErrorMessage] = useState(null);
-  const setCommitList = useCommitStore((state) => state.setCommitList);
   const setRepository = useCommitStore((state) => state.setRepository);
+  const setCommitList = useCommitStore((state) => state.setCommitList);
+  const setCommitFormatStyle = useCommitStore(
+    (state) => state.setCommitFormatStyle
+  );
   const setTotalNumOfCommit = useCommitStore(
     (state) => state.setTotalNumOfCommit
   );
@@ -66,10 +72,13 @@ const useValidateCommit = () => {
 
       setCommitList(commitWithDiff);
 
+      const formatStyleCountInfo = getFormatStyleAndRate(commitsToCheck);
+      setCommitFormatStyle(formatStyleCountInfo);
+
       const totalCommitQualityInfo = getCommitSummary(commitWithDiff);
       setCommitSummary(totalCommitQualityInfo);
     },
-    [setCommitList, setCommitSummary, setTotalNumOfCommit]
+    [setCommitFormatStyle, setCommitList, setCommitSummary, setTotalNumOfCommit]
   );
 
   const handleCheckCommitQuality = useCallback(

--- a/src/pages/MyCommitScoreboard/index.jsx
+++ b/src/pages/MyCommitScoreboard/index.jsx
@@ -1,9 +1,10 @@
+import CommitFormatStyleValue from "../../features/commit/components/CommitFormatStyleValue";
 import GithubAPIStatus from "../../features/githubAPIStatus/components/GithubAPIStatus";
 import RepositoryLinkTag from "../../features/repository/components/RepositoryLinkTag";
+import HomeButton from "../../shared/components/HomeButton";
 import ScoreBoardHeader from "./components/ScoreBoardHeader";
 import ScoreBoardRow from "./components/ScoreBoardRow";
 import useShowCommitDetails from "./hooks/useShowCommitDetails";
-import HomeButton from "../../shared/components/HomeButton";
 
 const GRID_COLS = "grid-cols-16";
 
@@ -11,19 +12,24 @@ const MyCommitScoreboard = () => {
   const { commitList } = useShowCommitDetails();
 
   return (
-    <>
-      <div className="m-4 flex w-full flex-row items-center justify-between px-10 py-5">
-        <div className="flex flex-row items-center">
-          <HomeButton />
-          <RepositoryLinkTag />
+    <div className="relative">
+      <div className="sticky left-0 right-0 top-0 z-50 shadow-xl">
+        <div className="flex w-full flex-row items-center justify-between bg-transparent px-10 py-5 backdrop-blur-xl">
+          <div className="flex flex-row items-end">
+            <HomeButton />
+            <div className="flex flex-col">
+              <CommitFormatStyleValue />
+              <RepositoryLinkTag />
+            </div>
+          </div>
+          <GithubAPIStatus />
         </div>
-        <GithubAPIStatus />
+        <ScoreBoardHeader gridCols={GRID_COLS} />
       </div>
-      <ScoreBoardHeader gridCols={GRID_COLS} />
       {commitList.map((commit) => (
         <ScoreBoardRow key={commit.sha} gridCols={GRID_COLS} commit={commit} />
       ))}
-    </>
+    </div>
   );
 };
 

--- a/src/shared/components/HomeButton.jsx
+++ b/src/shared/components/HomeButton.jsx
@@ -8,7 +8,7 @@ const HomeButton = () => {
   return (
     <button
       onClick={handleRoutingHome}
-      className="mr-6 rounded-full border border-slate-200 bg-white p-3 text-sm font-medium text-gray-900 hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-100 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:hover:border-gray-600 dark:hover:bg-gray-700 dark:focus:ring-gray-700"
+      className="mr-4 rounded-full bg-white p-3 text-sm font-medium text-gray-900 transition duration-300 ease-in-out hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-100 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:hover:border-gray-600 dark:hover:bg-gray-700 dark:focus:ring-gray-700"
     >
       <img src={HomeIcon} alt="go home" width={24} className="fill-blue-500" />
     </button>


### PR DESCRIPTION
# 이슈

🔗 이슈 링크 https://github.com/git-marvel/commit-guardians-client/issues/77

# 요약
- 디테일 페이지에서 커밋메세지의 형식을 보여줍니다. 

# 구현화면
<img width="1800" alt="Screenshot 2024-11-17 at 12 59 56 AM" src="https://github.com/user-attachments/assets/6df228ea-916d-43bd-afa6-caf04d12f754">

# 작업내용

- [x] commitMessage 의 타이틀만 보여주기
- [x] css 디자인 일괄 적용
- [x] formatStyle 도 디테일페이지에 보여주기

# 참고사항

- x

# PR 체크 사항

## 주의 사항

- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] format 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.

---

## 리뷰 반영사항


