### PR TITLE
fix: prefix-style 스코프가 존재해도, 타입 검사가능하도록 문제해결 및 simple-text-style 의 splitWith 재검토

### DIFF
--- a/src/entities/commit/enum/commitFormatStyleEnum.js
+++ b/src/entities/commit/enum/commitFormatStyleEnum.js
@@ -8,7 +8,7 @@ const COMMIT_FORMAT_STYLE = {
   },
   simpleText: {
     type: "simple-text-style",
-    splitWith: " ",
+    splitWith: "",
   },
   templateBased: {
     type: "template-based",

--- a/src/entities/commit/services/index.js
+++ b/src/entities/commit/services/index.js
@@ -6,6 +6,7 @@ const EMOJI_REGEX =
   /([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g;
 
 const removeEmoji = (string) => string.replace(EMOJI_REGEX, "");
+const removeParentheses = (string) => string.replace(/\(.*?\)/g, "");
 const removeSpecialCharacters = (string) => string.replace(/[^a-zA-Z]/g, "");
 
 const getFormatStyle = (firstWord) => {
@@ -15,11 +16,14 @@ const getFormatStyle = (firstWord) => {
 };
 
 const getCheckableCommitType = (firstWord, formatStyle) => {
-  const commitTypeString = formatStyle
-    ? removeSpecialCharacters(firstWord.split(formatStyle.splitWith)[0])
-        .trim()
-        .toLowerCase()
-    : "";
+  if (!formatStyle) {
+    return;
+  }
+
+  const firstPart = firstWord.split(formatStyle.splitWith)[0];
+  const withoutParentheses = removeParentheses(firstPart);
+  const cleanedFirstPart = removeSpecialCharacters(withoutParentheses);
+  const commitTypeString = cleanedFirstPart.trim().toLowerCase();
 
   return COMMIT_TYPE.list.find((validType) =>
     validType.sameMeaningWords.has(commitTypeString)


### PR DESCRIPTION
# 이슈

🔗 이슈 링크 https://github.com/git-marvel/commit-guardians-client/issues/82

# 요약

- prefix-style 스코프가 존재해도, 타입 검사가능하도록 버그픽스했습니다.
- 첫단어로 무조건 잘라 검사하기 때문에 `simple-text-style` 이면 splitWith 을 "" 빈문자열로 만들어서 자르도록 합니다.

# 작업내용

- [x] 소괄호의 내부의 모든 문자열을 제거하고 나서, 특수문자 제거하도록 수정
- 참고링크: https://github.com/mwanago/nestjs-typescript
- [x] `simple-text-style` 이면 splitWith 을 "" 빈문자열로 만들기
- 참고링크: https://github.com/wonderful123/ESP32-Flow-Meter-Pulse-Multipler

# 참고사항

- x

# PR 체크 사항

## 주의 사항

- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] debugging 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.

---

## 리뷰 반영사항

- [ ]
