### PR TITLE
feat: 디테일 페이지 컬럼값에 추가 정보를 담은 Tooltip UI 구현

### DIFF
--- a/src/features/commit/components/InfoValue.jsx
+++ b/src/features/commit/components/InfoValue.jsx
@@ -1,0 +1,19 @@
+import PropTypes from "prop-types";
+import InfoIcon from "../../../shared/components/InfoIcon";
+
+const InfoValue = ({ text }) => {
+  return (
+    <span className="group">
+      <InfoIcon />
+      <span className="absolute bottom-9 rounded-full border border-blue-400 bg-slate-800 px-3 py-1 text-xs text-white opacity-0 transition duration-300 ease-in-out group-hover:opacity-100">
+        {text}
+      </span>
+    </span>
+  );
+};
+
+InfoValue.propTypes = {
+  text: PropTypes.string.isRequired,
+};
+
+export default InfoValue;

--- a/src/features/commit/components/InfoValue.jsx
+++ b/src/features/commit/components/InfoValue.jsx
@@ -1,19 +1,28 @@
 import PropTypes from "prop-types";
+import React from "react";
 import InfoIcon from "../../../shared/components/InfoIcon";
+import { INFO_MESSAGES } from "../constants";
 
-const InfoValue = ({ text }) => {
+const InfoValue = ({ type }) => {
+  const messages = INFO_MESSAGES[type];
+
   return (
     <span className="group">
       <InfoIcon />
-      <span className="absolute bottom-9 rounded-full border border-blue-400 bg-slate-800 px-3 py-1 text-xs text-white opacity-0 transition duration-300 ease-in-out group-hover:opacity-100">
-        {text}
+      <span className="absolute left-20 top-3 flex flex-col rounded-md border border-blue-400 bg-slate-800 px-3 py-1 text-white opacity-0 transition duration-300 ease-in-out group-hover:opacity-100">
+        {messages.map((message) => (
+          <React.Fragment key={message.title}>
+            <span className="mb-1 text-sm font-semibold">{message.title}</span>
+            <span className="mb-2 text-xs">{message.contents}</span>
+          </React.Fragment>
+        ))}
       </span>
     </span>
   );
 };
 
 InfoValue.propTypes = {
-  text: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired,
 };
 
 export default InfoValue;

--- a/src/features/commit/constants/index.js
+++ b/src/features/commit/constants/index.js
@@ -1,0 +1,17 @@
+const INFO_MESSAGES = {
+  scoreBoardChanges: [
+    {
+      title: "FILE ICON",
+      contents: "변경된 파일의 개수입니다.",
+    },
+    {
+      title: "CHANGES BAR",
+      contents: "전체 change의 개수 중 통과된 change의 비율입니다.",
+    },
+  ],
+  scoreBoardDate: [
+    { title: "", contents: new Date().toTimeString().substring(8) },
+  ],
+};
+
+export { INFO_MESSAGES };

--- a/src/pages/MyCommitScoreboard/components/ScoreBoardHeader.jsx
+++ b/src/pages/MyCommitScoreboard/components/ScoreBoardHeader.jsx
@@ -1,4 +1,7 @@
 import PropTypes from "prop-types";
+import InfoValue from "../../../features/commit/components/InfoValue";
+
+const time = new Date().toTimeString().substring(8);
 
 const ScoreBoardHeader = ({ gridCols }) => {
   return (
@@ -7,10 +10,16 @@ const ScoreBoardHeader = ({ gridCols }) => {
     >
       <p className="col-span-1 px-2 py-1">TYPE</p>
       <p className="col-span-6 px-2 py-1">COMMIT MESSAGE</p>
-      <p className="col-span-3 px-2 py-1">CHANGES</p>
+      <p className="relative col-span-3 px-2 py-1">
+        CHANGES
+        <InfoValue text="코드 수정에서 제거와 추가가 짝을 이루는 변경 단위" />
+      </p>
       <p className="col-span-1 px-2 py-1">SCORE</p>
       <p className="col-span-2 px-2 py-1">AUTHOR</p>
-      <p className="col-span-2 px-2 py-1">DATE</p>
+      <p className="relative col-span-2 px-2 py-1">
+        DATE
+        <InfoValue text={time} />
+      </p>
       <p className="col-span-1 px-2 py-1">SHA</p>
     </div>
   );

--- a/src/pages/MyCommitScoreboard/components/ScoreBoardHeader.jsx
+++ b/src/pages/MyCommitScoreboard/components/ScoreBoardHeader.jsx
@@ -1,8 +1,6 @@
 import PropTypes from "prop-types";
 import InfoValue from "../../../features/commit/components/InfoValue";
 
-const time = new Date().toTimeString().substring(8);
-
 const ScoreBoardHeader = ({ gridCols }) => {
   return (
     <div
@@ -12,13 +10,13 @@ const ScoreBoardHeader = ({ gridCols }) => {
       <p className="col-span-6 px-2 py-1">COMMIT MESSAGE</p>
       <p className="relative col-span-3 px-2 py-1">
         CHANGES
-        <InfoValue text="코드 수정에서 제거와 추가가 짝을 이루는 변경 단위" />
+        <InfoValue type="scoreBoardChanges" />
       </p>
       <p className="col-span-1 px-2 py-1">SCORE</p>
       <p className="col-span-2 px-2 py-1">AUTHOR</p>
       <p className="relative col-span-2 px-2 py-1">
         DATE
-        <InfoValue text={time} />
+        <InfoValue type="scoreBoardDate" />
       </p>
       <p className="col-span-1 px-2 py-1">SHA</p>
     </div>

--- a/src/pages/MyCommitScoreboard/components/ScoreBoardRow.jsx
+++ b/src/pages/MyCommitScoreboard/components/ScoreBoardRow.jsx
@@ -7,6 +7,8 @@ import CommitTypeValue from "../../../features/commit/components/CommitTypeValue
 import SHAValue from "../../../features/commit/components/SHAValue";
 
 const ScoreBoardRow = ({ gridCols, commit }) => {
+  const time = new Date(commit.author.date).toTimeString().slice(0, 8);
+
   return (
     <div
       className={`${gridCols} grid w-full items-center gap-4 px-10 py-2 text-base text-slate-800 transition duration-300 ease-in-out hover:bg-slate-100`}
@@ -28,9 +30,7 @@ const ScoreBoardRow = ({ gridCols, commit }) => {
       </div>
       <div className="col-span-2 px-2 py-1 text-sm">
         <p>{new Date(commit.author.date).toDateString()}</p>
-        <span className="text-xs text-slate-400">
-          {new Date(commit.author.date).toTimeString()}
-        </span>
+        <span className="text-xs text-slate-400">{time}</span>
       </div>
       <div className="col-span-1 px-2 py-1">
         <SHAValue sha={commit.sha} />

--- a/src/shared/components/InfoIcon.jsx
+++ b/src/shared/components/InfoIcon.jsx
@@ -1,0 +1,20 @@
+const InfoIcon = () => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth="1.5"
+      stroke="currentColor"
+      className="mb-1 ml-2 inline-block size-4 text-slate-300"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z"
+      />
+    </svg>
+  );
+};
+
+export default InfoIcon;


### PR DESCRIPTION
# 이슈

🔗 이슈 링크 https://github.com/git-marvel/commit-guardians-client/issues/80

# 요약

- 사용자가 scoreBoard에서 컬럼값 옆 아이콘을 마우스 호버하면 추가 설명이 나타납니다.


# 구현화면
<img src="https://github.com/user-attachments/assets/541eee84-c9fe-4b70-88bd-ab7a0fd3e827" width="300" height="190">
<img src="https://github.com/user-attachments/assets/2b26b0d3-0672-4432-9fa9-db1a0ecb2f29" width="300" height="190">

# 작업내용

- [x] CHANGES에 대한 설명 추가
- [x] DATE에 대한 설명 추가

# 참고사항

- time 변수
  -  [Date.prototype.toTimeString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toTimeString) 반환값의 앞 부분은 항상 HH:MM:SS 2자리씩 고정되어 있어서 그에 따라 slice()의 인덱스 값을 정하게 됐습니다.

# PR 체크 사항

## 주의 사항

- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!

---

## 리뷰 반영사항

- [x] CHANGES에 대한 설명 수정
- [x] 인포 관련 메시지 constant에서 다루는 것으로 수정
