### PR TITLE
fix: 정보표시 아이콘이 아닌 곳에서 마우스 호버됐을 때도 툴팁이 보여지는 문제 해결

### DIFF
--- a/src/features/commit/components/InfoValue.jsx
+++ b/src/features/commit/components/InfoValue.jsx
@@ -9,7 +9,7 @@ const InfoValue = ({ type }) => {
   return (
     <span className="group">
       <InfoIcon />
-      <span className="absolute left-20 top-3 flex flex-col rounded-md border border-blue-400 bg-slate-800 px-3 py-1 text-white opacity-0 transition duration-300 ease-in-out group-hover:opacity-100">
+      <span className="absolute left-20 top-3 hidden flex-col rounded-md border border-blue-400 bg-slate-800 px-3 py-1 text-white transition duration-300 ease-in-out group-hover:flex">
         {messages.map((message) => (
           <React.Fragment key={message.title}>
             <span className="mb-1 text-sm font-semibold">{message.title}</span>

--- a/src/features/commit/components/ShaHoverBox.jsx
+++ b/src/features/commit/components/ShaHoverBox.jsx
@@ -11,7 +11,7 @@ const ShaHoverBox = ({ copiedSha, shaType }) => {
 
   return (
     <p
-      className={`absolute bottom-1 -translate-y-full rounded-full border border-blue-400 px-2 py-1 text-xs ${isShaCopied ? "text-slate-800" : "text-white"} whitespace-nowrap opacity-0 shadow-sm transition duration-300 ease-in-out group-hover:opacity-100 ${isShaCopied ? "bg-blue-300" : "bg-slate-800"}`}
+      className={`absolute bottom-1 -translate-y-full rounded-full border border-blue-400 px-2 py-1 text-xs ${isShaCopied ? "text-slate-800" : "text-white"} hidden whitespace-nowrap shadow-sm transition duration-300 ease-in-out group-hover:flex ${isShaCopied ? "bg-blue-300" : "bg-slate-800"}`}
     >
       {isShaCopied ? "Copied ✔️" : `${shaType} Copy`}
     </p>

--- a/src/features/commitBadge/components/CopyBadge.jsx
+++ b/src/features/commitBadge/components/CopyBadge.jsx
@@ -22,7 +22,7 @@ const CopyBadge = () => {
           width={22}
           className="invert"
         />
-        <div className="absolute -bottom-2 left-6 w-64 translate-y-full rounded-full border border-blue-400 bg-sky-50 px-2 py-2 text-slate-800 opacity-0 shadow-sm transition duration-300 ease-in-out group-hover:opacity-100">
+        <div className="absolute -bottom-2 left-6 w-64 translate-y-full rounded-full border border-blue-400 bg-sky-50 px-2 py-2 text-slate-800 hidden shadow-sm transition duration-300 ease-in-out group-hover:flex">
           Paste your repository <b>README.md</b>
           <div className="absolute -top-2 left-14 h-4 w-4 rotate-45 transform border-l border-t border-blue-400 bg-sky-50"></div>
         </div>

--- a/src/features/commitBadge/components/CopyBadge.jsx
+++ b/src/features/commitBadge/components/CopyBadge.jsx
@@ -22,7 +22,7 @@ const CopyBadge = () => {
           width={22}
           className="invert"
         />
-        <div className="absolute -bottom-2 left-6 w-64 translate-y-full rounded-full border border-blue-400 bg-sky-50 px-2 py-2 text-slate-800 hidden shadow-sm transition duration-300 ease-in-out group-hover:flex">
+        <div className="absolute -bottom-2 left-6 hidden w-64 translate-y-full rounded-full border border-blue-400 bg-sky-50 px-2 py-2 text-slate-800 shadow-sm transition duration-300 ease-in-out group-hover:flex">
           Paste your repository <b>README.md</b>
           <div className="absolute -top-2 left-14 h-4 w-4 rotate-45 transform border-l border-t border-blue-400 bg-sky-50"></div>
         </div>


### PR DESCRIPTION
# 이슈

🔗 이슈 링크 https://github.com/git-marvel/commit-guardians-client/issues/80

# 요약

- 예) 복사아이콘, 정보 아이콘 등 메시지가 나타나도록 지정된 아이콘이 아닌 곳에서 마우스 호버됐을 때 메시지가 보여지는 문제입니다.

# 작업내용

- [x] Opacity를 hidden으로 변경

# PR 체크 사항

## PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
