### PR TITLE
fix: remove타입 점수 계산 로직 수정

### DIFF
--- a/src/entities/commit/services/__tests__/scoreRemoveCommitType.test.js
+++ b/src/entities/commit/services/__tests__/scoreRemoveCommitType.test.js
@@ -1,34 +1,8 @@
 import { describe, expect, it } from "vitest";
 import scoreRemoveCommitType, {
   calculateFileScore,
-  calculateModuleFileDeletions,
   isOnlyDeletionChange,
 } from "../scoreRemoveCommitType";
-
-// 모듈 파일의 유효한 삭제 변경사항 개수를 계산하는 함수에 대한 테스트
-describe("calculateModuleFileDeletions", () => {
-  const changes = [
-    { "-": "minus library", "+": "" },
-    { "-": "minus library2", "+": "" },
-  ];
-
-  it("JSON 파일일 경우 changes를 반환해야 합니다.", () => {
-    expect(calculateModuleFileDeletions("test.json", changes)).toBe(
-      changes.length
-    );
-  });
-
-  it("YAML 파일일 경우 true를 반환해야 합니다.", () => {
-    expect(calculateModuleFileDeletions("test.yaml", changes)).toBe(
-      changes.length
-    );
-  });
-
-  it("모듈 파일이 아닐 경우 undefined를 반환해야 합니다.", () => {
-    expect(calculateModuleFileDeletions("test.js", changes)).toBe(undefined);
-    expect(calculateModuleFileDeletions("test.ts", changes)).toBe(undefined);
-  });
-});
 
 // 삭제만 있는 변경사항인지 확인하는 함수에 대한 테스트
 describe("isOnlyDeletionChange", () => {

--- a/src/entities/commit/services/scoreRemoveCommitType.js
+++ b/src/entities/commit/services/scoreRemoveCommitType.js
@@ -1,34 +1,5 @@
-const MODULE_FILE_EXTENSIONS = [".json", ".yaml"];
-
 /**
- * 조건 1. 모듈 파일의 유효한 삭제 변경사항 개수를 계산하는 함수
- * @param {string} fileName - 파일 이름
- * @param {Array} changes - 변경사항 목록
- * @returns {number || undefined} - 유효한 삭제 변경사항 개수 (순수 삭제 - 수정) || 모듈파일 확장자가 아닌 경우 undefined 를 반환
- */
-const calculateModuleFileDeletions = (fileName, changes) => {
-  if (
-    !MODULE_FILE_EXTENSIONS.some((extension) => fileName.endsWith(extension))
-  ) {
-    return;
-  }
-
-  const pureDeletions = changes.filter((change) =>
-    isOnlyDeletionChange(change)
-  );
-
-  const modifications = changes.filter((change) => {
-    const hasDeletion = change["-"] !== undefined && change["-"].length > 0;
-    const hasAddition = change["+"] !== undefined && change["+"].length > 0;
-
-    return hasDeletion && hasAddition;
-  });
-
-  return pureDeletions.length - modifications.length;
-};
-
-/**
- * 조건 2. 변경사항이 삭제만 있는지 확인하는 함수입니다.
+ * 변경사항이 삭제만 있는지 확인하는 함수입니다.
  * @param {Object} change - 변경사항 객체
  * @returns {boolean} - 삭제만 있는지 여부
  */
@@ -51,12 +22,6 @@ const calculateFileScore = (fileName, changes) => {
 
   if (!changes || changesLength === 0) {
     return 0;
-  }
-
-  const numOfPerfectChanges = calculateModuleFileDeletions(fileName, changes);
-
-  if (numOfPerfectChanges !== undefined) {
-    return Math.floor((numOfPerfectChanges / changesLength) * 100);
   }
 
   const validDeletionCount = changes.reduce((count, change) => {
@@ -92,8 +57,4 @@ const scoreRemoveCommitType = (diffObj) => {
 };
 
 export default scoreRemoveCommitType;
-export {
-  calculateFileScore,
-  calculateModuleFileDeletions,
-  isOnlyDeletionChange,
-};
+export { calculateFileScore, isOnlyDeletionChange };


### PR DESCRIPTION
# 이슈

🔗 이슈 링크 https://github.com/git-marvel/commit-guardians-client/issues/4

# 요약

- scoreBoard의 커밋 점수가 마이너스가 발생하는 오류를 해결했습니다.

# 작업내용
![image](https://github.com/user-attachments/assets/09b5531b-9ae1-4e32-bd4a-874fd44f4cbe)

- [x] remove 타입 체크 로직에서 에러가 발생된 원인인 음수 값이 반환되는 부분 파악 후 불필요한 부분을 삭제했습니다.


# PR 체크 사항

## 주의 사항

- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.

---

## 리뷰 반영사항

- [ ]
