### PR TITLE
feat: 문서 주석(JSDoc, dartdoc) 수정 시 docs 타입으로 판단

### DIFF
--- a/src/entities/commit/services/scoreDocsCommitType.js
+++ b/src/entities/commit/services/scoreDocsCommitType.js
@@ -9,7 +9,10 @@ const DOCS_TYPE_FILENAME_EXTENSIONS = [
   ".svg",
   ".ai",
   ".pdf",
+  ".txt",
 ];
+
+const DOCS_COMMENTS = ["/** ", "* ", "/// "];
 
 const isDocsFile = (filePath) => {
   return DOCS_TYPE_FILENAME_EXTENSIONS.some((extension) =>
@@ -17,22 +20,65 @@ const isDocsFile = (filePath) => {
   );
 };
 
+const isDocsComments = (change) => {
+  const keyOfEmptyValue =
+    change["+"] === "" && change["-"] === ""
+      ? false
+      : change["+"] === ""
+        ? "+"
+        : change["-"] === ""
+          ? "-"
+          : true;
+
+  if (keyOfEmptyValue === false) {
+    return false;
+  }
+
+  return DOCS_COMMENTS.some((comment) => {
+    switch (keyOfEmptyValue) {
+      case "+":
+        return change["-"].startsWith(comment, 2);
+      case "-":
+        return change["+"].startsWith(comment, 2);
+      default:
+        return (
+          change["+"].startsWith(comment, 2) &&
+          change["-"].startsWith(comment, 2)
+        );
+    }
+  });
+};
+
+const calculateFileScore = (filePath, changes) => {
+  if (isDocsFile(filePath)) {
+    return 100;
+  } else if (changes.length === 0) {
+    return 0;
+  }
+
+  const validChanges = changes.reduce((count, change) => {
+    return isDocsComments(change) ? count + 1 : count;
+  }, 0);
+
+  return Math.floor((validChanges / changes.length) * 100);
+};
+
 /**
  * @param {Object} diffObj - 변경사항 객체
  * @returns {number} commitScore - 최종 점수
  */
 const scoreDocsCommitType = (diffObj) => {
-  const totalFiles = Object.keys(diffObj);
+  const totalFiles = Object.entries(diffObj);
 
-  if (totalFiles.length === 0) {
+  if (!totalFiles.length) {
     return 0;
   }
 
-  const passedFilesCount = totalFiles.reduce((count, filePath) => {
-    return isDocsFile(filePath) ? count + 1 : count;
+  const totalScore = totalFiles.reduce((sum, [filePath, changes]) => {
+    return sum + calculateFileScore(filePath, changes);
   }, 0);
 
-  const commitScore = Math.floor((passedFilesCount / totalFiles.length) * 100);
+  const commitScore = Math.floor(totalScore / totalFiles.length);
 
   return commitScore;
 };

--- a/src/entities/commit/services/scoreDocsCommitType.js
+++ b/src/entities/commit/services/scoreDocsCommitType.js
@@ -35,15 +35,17 @@ const isDocsComments = (change) => {
   }
 
   return DOCS_COMMENTS.some((comment) => {
+    const startIndex = 2;
+
     switch (keyOfEmptyValue) {
       case "+":
-        return change["-"].startsWith(comment, 2);
+        return change["-"].startsWith(comment, startIndex);
       case "-":
-        return change["+"].startsWith(comment, 2);
+        return change["+"].startsWith(comment, startIndex);
       default:
         return (
-          change["+"].startsWith(comment, 2) &&
-          change["-"].startsWith(comment, 2)
+          change["+"].startsWith(comment, startIndex) &&
+          change["-"].startsWith(comment, startIndex)
         );
     }
   });


### PR DESCRIPTION
# 이슈

🔗 이슈 링크 https://github.com/git-marvel/commit-guardians-client/issues/90

# 요약

- docs 타입인 커밋을 체크할 때 문서 주석(JSDoc, dartdoc)을 변경했을 경우도 인정되도록 추가되었습니다.


# 작업내용

- [x] `/** ... */` JSdoc을 변경한 케이스 추가
 - [x] `///` dartdoc을 변경한 케이스 추가


# PR 체크 사항

## 주의 사항

- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.

---

## 리뷰 반영사항

- [ ]
