### PR TITLE
refactor: remove타입 체크 로직에서 쓰이지 않는 파라미터 삭제

### DIFF
--- a/src/entities/commit/services/__tests__/scoreRemoveCommitType.test.js
+++ b/src/entities/commit/services/__tests__/scoreRemoveCommitType.test.js
@@ -26,12 +26,12 @@ describe("isOnlyDeletionChange", () => {
 describe("calculateFileScore", () => {
   it("모든 변경사항이 유효한 삭제일 경우 100% 점수를 반환해야 합니다.", () => {
     const changes = [{ "-": "deleted content" }, { "-": "deleted content" }];
-    expect(calculateFileScore("test.jsx", changes)).toBe(100);
+    expect(calculateFileScore(changes)).toBe(100);
   });
 
   it("삭제된 변경사항이 없을 경우 0% 점수를 반환해야 합니다.", () => {
     const changes = [{ "+": "added content" }, { "+": "added content" }];
-    expect(calculateFileScore("test.jsx", changes)).toBe(0);
+    expect(calculateFileScore(changes)).toBe(0);
   });
 
   it("절반의 변경사항만 유효한 삭제일 경우 50% 점수를 반환해야 합니다.", () => {
@@ -40,7 +40,7 @@ describe("calculateFileScore", () => {
       { "+": "added content" },
       { "-": "deleted content", "+": "added content" },
     ];
-    expect(calculateFileScore("test.jsx", changes)).toBe(33);
+    expect(calculateFileScore(changes)).toBe(33);
   });
 });
 

--- a/src/entities/commit/services/scoreRemoveCommitType.js
+++ b/src/entities/commit/services/scoreRemoveCommitType.js
@@ -14,10 +14,9 @@ const isOnlyDeletionChange = (change) => {
 /**
  * 파일별 삭제 점수를 계산하는 함수입니다.
  * @param {Array} changes - 파일의 변경사항 목록
- * @param {string} fileName - 파일 이름
  * @returns {number} - 파일의 삭제 점수
  */
-const calculateFileScore = (fileName, changes) => {
+const calculateFileScore = (changes) => {
   const changesLength = changes.length;
 
   if (!changes || changesLength === 0) {
@@ -41,16 +40,16 @@ const scoreRemoveCommitType = (diffObj) => {
     return 0;
   }
 
-  const validFiles = Object.entries(diffObj).filter(
-    ([, changes]) => Array.isArray(changes) && changes.length > 0
+  const validFiles = Object.values(diffObj).filter(
+    (changes) => Array.isArray(changes) && changes.length > 0
   );
 
   if (validFiles.length === 0) {
     return 0;
   }
 
-  const totalScore = validFiles.reduce((sum, [fileName, changes]) => {
-    return sum + calculateFileScore(fileName, changes);
+  const totalScore = validFiles.reduce((sum, changes) => {
+    return sum + calculateFileScore(changes);
   }, 0);
 
   return Math.floor(totalScore / validFiles.length);

--- a/src/pages/Home/api/index.js
+++ b/src/pages/Home/api/index.js
@@ -73,11 +73,11 @@ const getCommitDiff = async ({ owner, repo, sha }) => {
 
 const getCommitDiffList = async ({ owner, repo, commitsToCheck }) => {
   let answer = [];
-  const interationSize = Math.ceil(
+  const iterationSize = Math.ceil(
     commitsToCheck.length / DIFF_REQUEST_BATCH_SIZE
   );
 
-  for (let i = 0; i < interationSize; i++) {
+  for (let i = 0; i < iterationSize; i++) {
     const slicedCommitsToCheck = commitsToCheck.slice(
       DIFF_REQUEST_BATCH_SIZE * i,
       DIFF_REQUEST_BATCH_SIZE * (i + 1)


### PR DESCRIPTION
# 이슈

🔗 이슈 링크 https://github.com/git-marvel/commit-guardians-client/issues/4

# 요약

- remove타입 체크 로직이 수정된 후 더 이상 쓰이지 않는 파라미터를 삭제했습니다.


# 작업내용

- [x] filename 파라미터 삭제 후 연관된 테스트 코드 수정
- [x] remove 커밋 타입 검증 후 점수를 반환하는 함수에서 filename 삭제 후 불필요하게 된 로직 수정

# PR 체크 사항

## 주의 사항

- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.

---

## 리뷰 반영사항

- [ ]
