### PR TITLE
feat: 새로고침시에도 이전값을 라우팅하여 볼 수 있는 기능 추가

### DIFF
--- a/src/app/router.jsx
+++ b/src/app/router.jsx
@@ -1,20 +1,14 @@
 import { createBrowserRouter, redirect } from "react-router-dom";
-import useCommitStore from "../features/commit/store/useCommitStore";
+import usePersistentStore from "../shared/store/usePersistentStore";
 import Home from "../pages/Home";
 import MyCommitBadge from "../pages/MyCommitBadge";
 import MyCommitScoreboard from "../pages/MyCommitScoreboard";
 import NotFound from "../pages/NotFound";
 
-const usePossibleToCheck = () => {
-  const {
-    commitInfo: { numOfCommit },
-  } = useCommitStore.getState();
+const checkToRoute = () => {
+  const { isAbleToRoute } = usePersistentStore.getState();
 
-  if (!numOfCommit || numOfCommit === 0) {
-    return redirect("/");
-  }
-
-  return null;
+  return isAbleToRoute ? null : redirect("/");
 };
 
 const router = createBrowserRouter([
@@ -24,12 +18,12 @@ const router = createBrowserRouter([
   },
   {
     path: "/my-commit-badge",
-    loader: usePossibleToCheck,
+    loader: checkToRoute,
     element: <MyCommitBadge />,
   },
   {
     path: "/my-commit-scoreboard",
-    loader: usePossibleToCheck,
+    loader: checkToRoute,
     element: <MyCommitScoreboard />,
   },
   {

--- a/src/pages/Home/hooks/useValidateCommit.jsx
+++ b/src/pages/Home/hooks/useValidateCommit.jsx
@@ -109,7 +109,7 @@ const useValidateCommit = () => {
         setRepository({ owner, repo });
         await fetchCommits({ owner, repo });
 
-        if (numOfCommit !== 0) {
+        if (numOfCommit > 0) {
           setIsAbleToRoute(true);
         }
 

--- a/src/pages/Home/hooks/useValidateCommit.jsx
+++ b/src/pages/Home/hooks/useValidateCommit.jsx
@@ -7,6 +7,7 @@ import {
 } from "../../../entities/commit/services";
 import { getCommitSummary } from "../../../entities/score/services";
 import useCommitStore from "../../../features/commit/store/useCommitStore";
+import usePersistentStore from "../../../shared/store/usePersistentStore";
 import useGithubStatusStore from "../../../features/githubAPIStatus/store/useGithubStatusStore";
 import { ERROR_MESSAGES } from "../../../shared/constants";
 import extractGitInfoFromURL from "../../../shared/utils/extractGitInfoFromURL";
@@ -25,6 +26,9 @@ const useValidateCommit = () => {
   );
   const setTotalNumOfCommit = useCommitStore(
     (state) => state.setTotalNumOfCommit
+  );
+  const setIsAbleToRoute = usePersistentStore(
+    (state) => state.setIsAbleToRoute
   );
   const setCommitSummary = useCommitStore((state) => state.setCommitSummary);
   const numOfCommit = useCommitStore((state) => state.commitInfo.numOfCommit);
@@ -89,6 +93,8 @@ const useValidateCommit = () => {
   const handleCheckCommitQuality = useCallback(
     async (event) => {
       event.preventDefault();
+      setErrorMessage(null);
+      setIsAbleToRoute(false);
 
       try {
         setIsLoading(true);
@@ -103,6 +109,10 @@ const useValidateCommit = () => {
         setRepository({ owner, repo });
         await fetchCommits({ owner, repo });
 
+        if (numOfCommit !== 0) {
+          setIsAbleToRoute(true);
+        }
+
         setErrorMessage(
           numOfCommit === 0 ? ERROR_MESSAGES.noCommitsToCheck : null
         );
@@ -113,7 +123,7 @@ const useValidateCommit = () => {
         setIsLoading(false);
       }
     },
-    [fetchCommits, setRepository, numOfCommit]
+    [fetchCommits, setRepository, numOfCommit, setIsAbleToRoute]
   );
 
   return {

--- a/src/shared/store/usePersistentStore.js
+++ b/src/shared/store/usePersistentStore.js
@@ -1,0 +1,30 @@
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+const initialState = {
+  isAbleToRoute: false,
+};
+
+const usePersistentStore = create(
+  persist(
+    (set) => ({
+      ...initialState,
+
+      setIsAbleToRoute: (isStored) =>
+        set(() => ({
+          isAbleToRoute: isStored,
+        })),
+
+      clearAll: () =>
+        set(() => ({
+          ...initialState,
+        })),
+    }),
+    {
+      name: "session-storage",
+      storage: createJSONStorage(() => sessionStorage),
+    }
+  )
+);
+
+export default usePersistentStore;


### PR DESCRIPTION
# 이슈

🔗 이슈 링크 https://github.com/git-marvel/commit-guardians-client/issues/100

# 요약

- 새로고침시에도 이전값을 라우팅하여 볼 수 있습니다.

# 작업내용

- [x] 세션스토리지에 플래그 값을 추가했습니다.
- [x] useValidateCommit 훅을 실행할 때, 플래그 값을 동적으로 변경합니다..

# 참고사항

x

# PR 체크 사항

## 주의 사항

- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] refresh 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.

---

## 리뷰 반영사항

- [x] [refactor: 검사가능한 커밋갯수가 0 이 아니라고 판단하기 보다, 0 보다 클 때, 라우팅가능하도록 조건 명시](https://github.com/git-marvel/commit-guardians-client/pull/99/commits/a1e7c8a113e7afa5a14cf5f6f2ae6103d5030285)
