### PR TITLE
feat: 409에러에 대한 대응 추가

### DIFF
--- a/src/shared/constants/index.js
+++ b/src/shared/constants/index.js
@@ -7,6 +7,7 @@ const ERROR_MESSAGES = {
     "적합하지 않은 URL입니다. [https://github.com/소유자이름/레포지토리이름/...] 혹은 [github.com/소유자이름/레포지토리이름/] 처럼 URL를 넣어주세요!",
   invalidGithubURL:
     "소유자 혹은 레포지토리 이름을 찾을 수 없는 링크입니다. 혹시 레포지토리가 private으로 설정 되어있거나 잘못된 링크 인가요?",
+  noCommit: "현재 레포지토리에 커밋이 하나도 없네요!",
   rateLimitExceeded:
     "저희 Github Token 을 모두 소모했습니다! 조금 뒤에 다시 시도 해주세요!",
   networkError: "새로 고침 후 올바른 URL로 다시 시도 해주세요!",

--- a/src/shared/error/throwCustomErrorMessage.js
+++ b/src/shared/error/throwCustomErrorMessage.js
@@ -7,6 +7,8 @@ const throwFetchErrorMessage = (error) => {
       throw new Error(ERROR_MESSAGES.rateLimitExceeded);
     case 404:
       throw new Error(ERROR_MESSAGES.invalidGithubURL);
+    case 409:
+      throw new Error(ERROR_MESSAGES.noCommit);
     case 500:
       throw new Error(ERROR_MESSAGES.networkError);
     default:


### PR DESCRIPTION
# 이슈

🔗 이슈 링크: https://github.com/git-marvel/commit-guardians-client/issues/101

# 요약
참조하는 레포지토리에 아무 commit이 없으면 나타나는 409 에러에 대해 대응 메시지를 추가하였습니다.

# 구현화면
![image](https://github.com/user-attachments/assets/67b74086-11b7-4a25-88c8-1eaff093d992)


# 작업내용

- [x] 409에 대한 에러 분기 추가
- [x] 에러 메시지 추가

# 참고사항
없음
# PR 체크 사항
## PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.

---

## 리뷰 반영사항

- [ ]
