### PR TITLE
feat: GitHub API 요청 시 여러 토큰을 분산 사용하여 Rate Limit을 관리하는 로직 구현

### DIFF
--- a/src/shared/api/tokenManager.js
+++ b/src/shared/api/tokenManager.js
@@ -1,0 +1,40 @@
+/**
+ * 깃헙에서 인증된 사용자라면, 한시간 당 최대 요청수 5,000개
+ * https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#primary-rate-limit-for-authenticated-users
+ */
+const GITHUB_REQUEST_LIMIT = 5000;
+
+const tokenStates = [
+  {
+    token: import.meta.env.VITE_GITHUB_TOKEN,
+    remaining: GITHUB_REQUEST_LIMIT,
+  },
+  {
+    token: import.meta.env.VITE_GITHUB_TOKEN_1,
+    remaining: GITHUB_REQUEST_LIMIT,
+  },
+  {
+    token: import.meta.env.VITE_GITHUB_TOKEN_2,
+    remaining: GITHUB_REQUEST_LIMIT,
+  },
+  {
+    token: import.meta.env.VITE_GITHUB_TOKEN_3,
+    remaining: GITHUB_REQUEST_LIMIT,
+  },
+];
+
+const getBestGithubToken = () => {
+  tokenStates.sort((a, b) => b.remaining - a.remaining);
+
+  return tokenStates[0].token;
+};
+
+const updateTokenState = (token, remaining) => {
+  const tokenState = tokenStates.find((t) => t.token === token);
+
+  if (tokenState) {
+    tokenState.remaining = remaining;
+  }
+};
+
+export { getBestGithubToken, updateTokenState };

--- a/src/shared/api/tokenManager.js
+++ b/src/shared/api/tokenManager.js
@@ -10,15 +10,23 @@ const tokenStates = [
     remaining: GITHUB_REQUEST_LIMIT,
   },
   {
-    token: import.meta.env.VITE_GITHUB_TOKEN_1,
+    token:
+      import.meta.env.VITE_GITHUB_TOKEN_1 ?? import.meta.env.VITE_GITHUB_TOKEN,
     remaining: GITHUB_REQUEST_LIMIT,
   },
   {
-    token: import.meta.env.VITE_GITHUB_TOKEN_2,
+    token:
+      import.meta.env.VITE_GITHUB_TOKEN_2 ?? import.meta.env.VITE_GITHUB_TOKEN,
     remaining: GITHUB_REQUEST_LIMIT,
   },
   {
-    token: import.meta.env.VITE_GITHUB_TOKEN_3,
+    token:
+      import.meta.env.VITE_GITHUB_TOKEN_3 ?? import.meta.env.VITE_GITHUB_TOKEN,
+    remaining: GITHUB_REQUEST_LIMIT,
+  },
+  {
+    token:
+      import.meta.env.VITE_GITHUB_TOKEN_4 ?? import.meta.env.VITE_GITHUB_TOKEN,
     remaining: GITHUB_REQUEST_LIMIT,
   },
 ];

--- a/src/shared/constants/index.js
+++ b/src/shared/constants/index.js
@@ -1,5 +1,3 @@
-const GITHUB_TOKEN = import.meta.env.VITE_GITHUB_TOKEN;
-
 const ERROR_MESSAGES = {
   githubStatusError: "Github 상태가 원할하지 않습니다.",
   noCommitsToCheck: "아쉽게도, 현재 검사할 수 있는 커밋이 없습니다. 😥",
@@ -24,4 +22,4 @@ const ERROR_MESSAGES = {
     "데이터 베이스의 알 수 없는 오류가 발생 한 것 같아요, 페이지를 다시 로드 해주세요!",
 };
 
-export { ERROR_MESSAGES, GITHUB_TOKEN };
+export { ERROR_MESSAGES };


### PR DESCRIPTION
# 이슈

🔗 이슈 링크 https://github.com/git-marvel/commit-guardians-client/issues/41

# 요약

- GitHub API 요청 시 여러 토큰을 분산 사용하여 Rate Limit을 관리하는 로직 구현하여 사용자경험을 증진시켰습니다.

# 구현화면
- 개발환경 화면에서 콘솔을 확인해보면, 요청수에 따라 토큰이 알아서 바뀌어 분산요청을 하는 것을 확인할 수 있습니다.
<img width="1800" alt="Screenshot 2024-11-20 at 6 04 29 AM" src="https://github.com/user-attachments/assets/2c418639-2f1d-4584-ad55-d96a8e9558ab">

# 작업내용


- [x] 토큰을 여러개 생산하여 환경변수에 넣어둡니다.
- [x] remaining 을 체크하여, 가장 높은 순으로 정렬후, 0번째 토큰을 활용합니다.

# 참고사항

- **환경변수 설정하셔야 합니다! **

# PR 체크 사항

## 주의 사항

- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] githubToken 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.

---

## 리뷰 반영사항

- [ ]
