### PR TITLE
feat: my-commit-badge 화면에서 통계 그래프 출력

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "axios": "^1.7.7",
     "chart.js": "^4.4.6",
+    "chartjs-plugin-datalabels": "^2.2.0",
     "diff-match-patch": "^1.0.5",
     "firebase": "^11.0.1",
     "idb-keyval": "^6.2.1",

--- a/package.json
+++ b/package.json
@@ -15,10 +15,12 @@
   },
   "dependencies": {
     "axios": "^1.7.7",
+    "chart.js": "^4.4.6",
     "diff-match-patch": "^1.0.5",
     "firebase": "^11.0.1",
     "idb-keyval": "^6.2.1",
     "react": "^18.3.1",
+    "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.27.0",
     "tailwindcss": "^3.4.14",

--- a/src/pages/MyCommitBadge/components/ChartContainer.jsx
+++ b/src/pages/MyCommitBadge/components/ChartContainer.jsx
@@ -1,0 +1,206 @@
+import { Bar, Doughnut } from "react-chartjs-2";
+import {
+  Chart as ChartJS,
+  ArcElement,
+  Tooltip,
+  Legend,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+} from "chart.js";
+import ChartDataLabels from "chartjs-plugin-datalabels";
+import useCommitStore from "../../../features/commit/store/useCommitStore";
+
+ChartJS.register(
+  ArcElement,
+  Tooltip,
+  Legend,
+  CategoryScale,
+  LinearScale,
+  BarElement
+);
+
+const ChartContainer = () => {
+  const commitList = useCommitStore((state) => state.commitInfo.commitList);
+
+  const people = new Map();
+  const type = new Map([
+    ["remove", 0],
+    ["style", 0],
+    ["docs", 0],
+    ["test", 0],
+  ]);
+
+  commitList.forEach((element) => {
+    const key = element.type;
+    type.set(key, type.get(key) + 1);
+
+    const email = element.author.email;
+    const author = element.author;
+
+    if (people.has(email)) {
+      const existing = people.get(email);
+      people.set(email, { ...existing, count: existing.count + 1 });
+    } else {
+      people.set(email, { ...author, count: 1 });
+    }
+  });
+
+  const pieData = {
+    labels: Array.from(type.keys()),
+    datasets: [
+      {
+        label: "Commits",
+        data: Array.from(type.values()),
+        backgroundColor: [
+          "rgba(255, 99, 132, 0.2)",
+          "rgba(54, 162, 235, 0.2)",
+          "rgba(255, 206, 86, 0.2)",
+          "rgba(75, 192, 192, 0.2)",
+          "rgba(153, 102, 255, 0.2)",
+          "rgba(255, 159, 64, 0.2)",
+        ],
+        borderColor: [
+          "rgba(255, 99, 132, 1)",
+          "rgba(54, 162, 235, 1)",
+          "rgba(255, 206, 86, 1)",
+          "rgba(75, 192, 192, 1)",
+          "rgba(153, 102, 255, 1)",
+          "rgba(255, 159, 64, 1)",
+        ],
+        borderWidth: 1,
+      },
+    ],
+  };
+
+  const pieOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      tooltip: {
+        callbacks: {
+          label: function (tooltipItem) {
+            return `${tooltipItem.label}: ${tooltipItem.raw}`;
+          },
+        },
+      },
+      legend: {
+        display: true,
+      },
+    },
+  };
+
+  const centerTextPlugin = {
+    id: "centerText",
+    beforeDraw: (chart) => {
+      const { width, ctx, data } = chart;
+      const total = data.datasets[0].data.reduce((a, b) => a + b, 0);
+
+      ctx.save();
+      ctx.font = "bold 16px Arial";
+      ctx.fillStyle = "rgba(100, 100, 100, 1)";
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+
+      const centerX = width / 2;
+      const centerY = chart.chartArea.height * (3 / 4) + 2;
+      ctx.fillText(`Total: ${total}`, centerX, centerY);
+
+      ctx.restore();
+    },
+  };
+
+  const sectionValuePlugin = {
+    id: "sectionValue",
+    afterDatasetDraw: (chart) => {
+      const { ctx, data } = chart;
+      const dataset = data.datasets[0];
+      const total = dataset.data.reduce((a, b) => a + b, 0);
+      const backgroundColor = [
+        "rgba(255, 99, 132, 1)",
+        "rgba(54, 162, 235, 1)",
+        "rgba(255, 206, 86, 1)",
+        "rgba(75, 192, 192, 1)",
+        "rgba(153, 102, 255, 1)",
+        "rgba(255, 159, 64, 1)",
+      ];
+
+      chart.getDatasetMeta(0).data.forEach((arc, index) => {
+        const { x, y } = arc.tooltipPosition();
+        const value = dataset.data[index];
+        const percentage = ((value / total) * 100).toFixed(1);
+        const sectionColor = backgroundColor[index];
+
+        ctx.save();
+        ctx.fillStyle = sectionColor;
+        ctx.font = "bold 10px Arial";
+        ctx.textAlign = "center";
+        ctx.textBaseline = "middle";
+
+        ctx.fillText(`${value} (${percentage}%)`, x, y);
+
+        ctx.restore();
+      });
+    },
+  };
+
+  const barData = {
+    labels: Array.from(people.values().map((element) => element.name)),
+    datasets: [
+      {
+        label: "Commits",
+        data: Array.from(people.values().map((element) => element.count)),
+        backgroundColor: "rgba(75, 192, 192, 0.2)",
+        borderColor: "rgba(75, 192, 192, 1)",
+        borderWidth: 1,
+      },
+    ],
+  };
+
+  const barOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      datalabels: {
+        color: "rgba(75, 192, 192, 1)",
+        anchor: "end",
+        align: "top",
+        font: {
+          size: 14,
+          weight: "bold",
+        },
+      },
+    },
+    scales: {
+      x: {
+        beginAtZero: true,
+        grid: {
+          color: "transparent",
+        },
+      },
+      y: {
+        beginAtZero: true,
+        grid: {
+          color: "transparent",
+        },
+      },
+    },
+  };
+
+  return (
+    <div className="flex items-center justify-center space-x-4">
+      <div className="h-64 w-64">
+        <Doughnut
+          data={pieData}
+          options={pieOptions}
+          plugins={[centerTextPlugin, sectionValuePlugin]}
+        />
+      </div>
+      <div className="h-64 w-64">
+        <Bar data={barData} options={barOptions} plugins={[ChartDataLabels]} />
+      </div>
+    </div>
+  );
+};
+
+export default ChartContainer;

--- a/src/pages/MyCommitBadge/index.jsx
+++ b/src/pages/MyCommitBadge/index.jsx
@@ -4,15 +4,12 @@ import CopyBadgeButton from "../../features/commitBadge/components/CopyBadge";
 import Button from "../../shared/components/Button";
 import Footer from "../../shared/components/Footer";
 import HomeButton from "../../shared/components/HomeButton";
+import ChartContainer from "./components/ChartContainer";
 
 const MyCommitBadge = () => {
   const navigate = useNavigate();
   const handleRoutingCommitScoreboard = () => navigate("/my-commit-scoreboard");
-  const numOfPerfectCommits = useCommitStore(
-    (state) => state.commitSummary.numOfPerfectCommits
-  );
   const totalScore = useCommitStore((state) => state.commitSummary.totalScore);
-  const numOfCommit = useCommitStore((state) => state.commitInfo.numOfCommit);
 
   return (
     <div className="h-screen w-screen bg-gray-100">
@@ -20,19 +17,12 @@ const MyCommitBadge = () => {
         <HomeButton />
       </div>
       <div className="flex flex-col items-center justify-center">
-        {numOfPerfectCommits && (
-          <div className="mb-10 flex items-center font-bold text-slate-500">
-            <span className="mr-1 text-2xl text-sky-300">
-              {numOfPerfectCommits}
-            </span>
-            <span className="text-sm text-slate-300">commits</span>
-          </div>
-        )}
+        <ChartContainer />
         {totalScore && (
           <>
             <p className="font-bold text-slate-500">Total Score</p>
             <h1 className="mb-4 px-4 text-4xl font-bold text-blue-400">
-              + {totalScore}
+              {totalScore} / 100
             </h1>
           </>
         )}
@@ -40,9 +30,6 @@ const MyCommitBadge = () => {
           <Button onClick={handleRoutingCommitScoreboard}>
             <>
               <span>View All Results</span>
-              <span className="ml-2 inline-flex h-6 w-6 items-center justify-center rounded-full bg-sky-200 text-xs font-semibold text-blue-800">
-                {numOfCommit}
-              </span>
             </>
           </Button>
         </div>


### PR DESCRIPTION
# 이슈

🔗 이슈 링크

# 요약
my-commit-badge 화면에서 검사한 commit에 대한 type과 author 별로 통계 그래프를 보여줍니다.
100점 커밋의 개수를 제거했습니다. 
총 검사한 커밋의 개수는 도넛 그래프 안에 보여지게 됩니다.
점수 표시 방식이 100만점으로 표시됩니다.

# 구현화면
![image](https://github.com/user-attachments/assets/fc4ed601-e95b-4e42-93d8-5f1bcbca5921)

# 작업내용

- [x] 검사한 commit에 대한 type 별 통계 그래프
- [x] 검사한 commit에 대한 author 별 통계 그래프

# 참고사항
- 없음

# PR 체크 사항

## PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.

---

## 리뷰 반영사항

- [ ]
