### PR TITLE
fix: changes의 barGraph의 길이가 최대 width 보다 큰 경우 비율로 표시

### DIFF
--- a/src/features/commit/components/ChangesValue.jsx
+++ b/src/features/commit/components/ChangesValue.jsx
@@ -11,7 +11,9 @@ const ChangesValue = memo(function ChangesValue({ commit }) {
   return (
     <div className="flex">
       <FileIcon />
-      <p className="pl-1 pr-4 font-bold text-slate-400">{commit.numOfFiles}</p>
+      <p className="w-10 pl-1 pr-4 font-bold text-slate-400">
+        {commit.numOfFiles}
+      </p>
       <BarGraph
         totalChanges={commit.numOfChanges}
         qualityScore={commit.qualityScore}

--- a/src/shared/components/BarGraph.jsx
+++ b/src/shared/components/BarGraph.jsx
@@ -4,8 +4,12 @@ const MAX_WIDTH = 20;
 
 function BarGraph({ totalChanges, qualityScore }) {
   const width = Math.min(totalChanges, MAX_WIDTH) * 10;
-  const scoreWidth =
+  let scoreWidth =
     Math.min((totalChanges * qualityScore) / 100, MAX_WIDTH) * 10;
+
+  if (totalChanges > (MAX_WIDTH * 10) / qualityScore) {
+    scoreWidth = width * (qualityScore / 100);
+  }
 
   return (
     <>

--- a/src/shared/components/BarGraph.jsx
+++ b/src/shared/components/BarGraph.jsx
@@ -1,15 +1,10 @@
 import PropTypes from "prop-types";
 
-const MAX_WIDTH = 20;
+const MAX_CHANGES = 20;
 
 function BarGraph({ totalChanges, qualityScore }) {
-  const width = Math.min(totalChanges, MAX_WIDTH) * 10;
-  let scoreWidth =
-    Math.min((totalChanges * qualityScore) / 100, MAX_WIDTH) * 10;
-
-  if (totalChanges > (MAX_WIDTH * 10) / qualityScore) {
-    scoreWidth = width * (qualityScore / 100);
-  }
+  const width = Math.min(totalChanges, MAX_CHANGES) * 10;
+  const scoreWidth = Math.min(width * (qualityScore / 100), MAX_CHANGES * 10);
 
   return (
     <>


### PR DESCRIPTION
# 이슈

🔗 이슈 링크

# 요약

- 결과 목록 페이지: 전체 changes 의 개수로 인해 barGraph의 최대 길이로 나타낼 수 있는 범위를 넘었을 경우에 제대로 표시되지 않는 에러를 수정했습니다.

# 구현화면
## As-is
![scorebar 수정 전](https://github.com/user-attachments/assets/a19ed2aa-c4d9-4dc0-8d54-d0fd2ddc2067)

## To-be
![scorebar 수정 후](https://github.com/user-attachments/assets/736af046-2d13-46fb-ad69-29d8c18347e8)


# 작업내용

- [x] changes의 비율을 나타내는 barGraph를 수정했습니다.


# PR 체크 사항

## 주의 사항

- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!

---

## 리뷰 반영사항

- [ ]
