### PR TITLE
test: getCommitSummary 커밋목록을 받아 총점을 계산하는 로직 테스트 코드 작성

### DIFF
--- a/src/entities/score/services/__tests__/getCommitSummary.test.js
+++ b/src/entities/score/services/__tests__/getCommitSummary.test.js
@@ -56,9 +56,9 @@ describe("getCommitSummary", () => {
       return list;
     };
 
-    const commitList = [{ qualityScore: 100 }, ...generateZeroScore(100)];
-
-    const result = getCommitSummary(commitList);
+    const allCommits = generateZeroScore(100);
+    allCommits.push({ qualityScore: 100 });
+    const result = getCommitSummary(allCommits);
 
     expect(result).toEqual({
       numOfPerfectCommits: 1,

--- a/src/entities/score/services/__tests__/getCommitSummary.test.js
+++ b/src/entities/score/services/__tests__/getCommitSummary.test.js
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { getCommitSummary } from "..";
+
+describe("getCommitSummary", () => {
+  it("커밋 목록들을 받아서, 전체 점수와 100점인 커밋갯수를 올바르게 계산할 수 있어야한다.", () => {
+    const commitList = [
+      { qualityScore: 100 },
+      { qualityScore: 90 },
+      { qualityScore: 100 },
+    ];
+
+    const result = getCommitSummary(commitList);
+
+    expect(result).toEqual({
+      numOfPerfectCommits: 2,
+      totalScore: 96, // (100 + 90 + 100) / 3 = 96.666 => 96
+    });
+  });
+
+  it("검사한 모든 커밋목록들이 100점이라면, 총 점수는 100점이어야 한다.", () => {
+    const commitList = [
+      { qualityScore: 100 },
+      { qualityScore: 100 },
+      { qualityScore: 100 },
+    ];
+
+    const result = getCommitSummary(commitList);
+
+    expect(result).toEqual({
+      numOfPerfectCommits: 3,
+      totalScore: 100,
+    });
+  });
+
+  it("커밋목록들 중에, 100점인 커밋이 하나도 없어도 점수를 낼 수 있어야 한다.", () => {
+    const commitList = [
+      { qualityScore: 50 },
+      { qualityScore: 75 },
+      { qualityScore: 25 },
+    ];
+
+    const result = getCommitSummary(commitList);
+
+    expect(result).toEqual({
+      numOfPerfectCommits: 0,
+      totalScore: 50,
+    });
+  });
+
+  it("하나만 100점이었고, 총점이 소수점 내림으로 인해 0점이 된 경우에는 총점 1점으로 간주한다.", () => {
+    const generateZeroScore = (number) => {
+      const list = [];
+      for (let i = 0; i < number; i++) {
+        list.push({ qualityScore: 0 });
+      }
+      return list;
+    };
+
+    const commitList = [{ qualityScore: 100 }, ...generateZeroScore(100)];
+
+    const result = getCommitSummary(commitList);
+
+    expect(result).toEqual({
+      numOfPerfectCommits: 1,
+      totalScore: 1,
+    });
+  });
+});


### PR DESCRIPTION
# 이슈

[🔗 이슈 링크](https://github.com/git-marvel/commit-guardians-client/issues/19)

# 요약

- getCommitSummary 커밋목록을 받아 총점을 계산하는 로직 테스트 코드 작성했습니다.

# 작업내용

- [x] 커밋 목록들을 받아서, 전체 점수와 100점인 커밋갯수를 올바르게 계산할 수 있어야한다
- [x] 검사한 모든 커밋목록들이 100점이라면, 총 점수는 100점이어야 한다
- [x] 커밋목록들 중에, 100점인 커밋이 하나도 없어도 점수를 낼 수 있어야 한다
- [x] 하나만 100점이었고, 총점이 소수점 내림으로 인해 0점이 된 경우에는 총점 1점으로 간주한다

# 참고사항

# PR 체크 사항

## 주의 사항

- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.

---

## 리뷰 반영사항

- [ ]
